### PR TITLE
Fontify tables, block delimiters, and attribute values

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,12 @@
 
 == main (unreleased)
 
+=== New Features
+
+* Fontify table delimiters (`|===`) and cell format specifiers.
+* Fontify delimited block markers for listing, literal, passthrough, open, quote, and example blocks.
+* Fontify document attribute values (e.g. `Jane Doe` in `:author: Jane Doe`).
+
 == 0.1.0 (2026-02-22)
 
 Initial release.

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -159,6 +159,25 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
 
    :language 'asciidoc
    :override t
+   :feature 'delimiter
+   '((listing_block_start_marker) @font-lock-delimiter-face
+     (listing_block_end_marker) @font-lock-delimiter-face
+     (literal_block_marker) @font-lock-delimiter-face
+     (passthrough_block_marker) @font-lock-delimiter-face
+     (open_block_marker) @font-lock-delimiter-face
+     (quoted_block_start_marker) @font-lock-delimiter-face
+     (quoted_block_end_marker) @font-lock-delimiter-face
+     (delimited_block_start_marker) @font-lock-delimiter-face
+     (delimited_block_end_marker) @font-lock-delimiter-face)
+
+   :language 'asciidoc
+   :override t
+   :feature 'table
+   '((table_block_marker) @font-lock-delimiter-face
+     (table_cell_attr) @font-lock-preprocessor-face)
+
+   :language 'asciidoc
+   :override t
    :feature 'list
    '((ordered_list_marker) @font-lock-constant-face
      (unordered_list_marker) @font-lock-constant-face
@@ -175,6 +194,7 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
    :override t
    :feature 'attribute
    '((document_attr (attr_name) @font-lock-variable-name-face)
+     (document_attr (line) @font-lock-string-face)
      (element_attr) @font-lock-preprocessor-face)
 
    :language 'asciidoc
@@ -228,7 +248,7 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
 
 (defvar asciidoc--treesit-font-lock-feature-list
   '((comment title)
-    (block list admonition attribute macro metadata)
+    (block delimiter table list admonition attribute macro metadata)
     (inline-markup inline-link inline-macro inline-reference)
     (replacement))
   "Font-lock feature list for `asciidoc-mode'.")

--- a/test/asciidoc-mode-integration-test.el
+++ b/test/asciidoc-mode-integration-test.el
@@ -151,7 +151,13 @@ OCCURRENCE selects which match (default 1)."
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "toc::")
-              :to-equal 'font-lock-function-call-face))))
+              :to-equal 'font-lock-function-call-face)))
+
+  (it "fontifies table delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-sample-buffer
+      (expect (asciidoc-test-face-at-match "|===")
+              :to-equal 'font-lock-delimiter-face))))
 
 ;;; Block-level override
 

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -176,6 +176,72 @@
       (expect (asciidoc-test-face-at (point))
               :to-equal 'font-lock-comment-delimiter-face))))
 
+;;; Font-lock: block delimiters
+
+(describe "Font-lock: block delimiters"
+  :var (skip-reason)
+  (before-all
+    (unless asciidoc-test-grammars-available
+      (setq skip-reason "tree-sitter grammars not installed")))
+
+  (it "fontifies listing block delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "----\ncode\n----\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face)))
+
+  (it "fontifies literal block delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "....\nlit\n....\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face)))
+
+  (it "fontifies passthrough block delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "++++\npass\n++++\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face)))
+
+  (it "fontifies open block delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "--\nopen\n--\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face)))
+
+  (it "fontifies quote block delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "____\nquote\n____\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face)))
+
+  (it "fontifies example block delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "====\nexample\n====\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face))))
+
+;;; Font-lock: tables
+
+(describe "Font-lock: tables"
+  :var (skip-reason)
+  (before-all
+    (unless asciidoc-test-grammars-available
+      (setq skip-reason "tree-sitter grammars not installed")))
+
+  (it "fontifies table delimiters"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "|===\n| A | B\n|===\n"
+      (expect (asciidoc-test-face-at 1)
+              :to-equal 'font-lock-delimiter-face)))
+
+  (it "fontifies table cell format specifiers"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "|===\na| x\n|===\n"
+      ;; The "a" cell-format spec on line 2 should get preprocessor face.
+      (let ((pos (string-match "a| x" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ pos))
+                :to-equal 'font-lock-preprocessor-face)))))
+
 ;;; Font-lock: attributes
 
 (describe "Font-lock: attributes"
@@ -189,7 +255,14 @@
     (with-fontified-asciidoc-buffer ":author: Someone\n"
       ;; "author" should get variable-name face
       (expect (asciidoc-test-face-at 2)
-              :to-equal 'font-lock-variable-name-face))))
+              :to-equal 'font-lock-variable-name-face)))
+
+  (it "fontifies document attribute value"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer ":author: Jane Doe\n"
+      (let ((pos (string-match "Jane" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ pos))
+                :to-equal 'font-lock-string-face)))))
 
 ;;; Font-lock: admonitions
 

--- a/test/fixtures/sample.adoc
+++ b/test/fixtures/sample.adoc
@@ -41,6 +41,13 @@ An indented literal block:
 
   $ make install
 
+A table:
+
+|===
+| Name | Value
+| foo | bar
+|===
+
 == Admonitions and Blocks
 
 NOTE: Remember to save your work.


### PR DESCRIPTION
The grammar already produces nodes for tables, block delimiters, and document attribute values, but the mode never mapped them to faces, so they rendered as plain text. This wires up font-lock for the table and delimiter constructs and for the value half of document attributes.

Adds two toggleable features (`table`, `delimiter`) at decoration level 2, with tests and a table added to the integration fixture. Came out of an audit against the official AsciiDoc spec.