### PR TITLE
Fix admonition fontification clobbering inline markup

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,10 @@
 
 == main (unreleased)
 
+=== Bug Fixes
+
+* Fix admonition fontification: highlight the label (e.g. `NOTE:`) instead of the body, so inline markup such as `code` and links inside an admonition is no longer clobbered. This also covers multi-line admonitions.
+
 == 0.2.0 (2026-06-02)
 
 === New Features

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -187,11 +187,6 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
 
    :language 'asciidoc
    :override t
-   :feature 'admonition
-   '((admonition) @font-lock-keyword-face)
-
-   :language 'asciidoc
-   :override t
    :feature 'attribute
    '((document_attr (attr_name) @font-lock-variable-name-face)
      (document_attr (line) @font-lock-string-face)
@@ -248,10 +243,22 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
 
 (defvar asciidoc--treesit-font-lock-feature-list
   '((comment title)
-    (block delimiter table list admonition attribute macro metadata)
+    (block delimiter table list attribute macro metadata)
     (inline-markup inline-link inline-macro inline-reference)
     (replacement))
   "Font-lock feature list for `asciidoc-mode'.")
+
+;;; Admonition labels
+
+;; The block grammar consumes a paragraph-style admonition label (e.g.
+;; \"NOTE\") without emitting a node for it, so it can't be highlighted
+;; via tree-sitter.  A small font-lock keyword fills the gap and, unlike
+;; the previous tree-sitter rule, leaves the admonition body to inline
+;; fontification instead of overriding it.
+(defvar asciidoc--admonition-font-lock-keywords
+  '(("^\\(?:NOTE\\|TIP\\|IMPORTANT\\|CAUTION\\|WARNING\\):"
+     0 'font-lock-keyword-face t))
+  "Font-lock keywords for paragraph-style admonition labels.")
 
 ;;; Imenu
 
@@ -323,7 +330,11 @@ Install them with \\[asciidoc-install-grammars].
     (treesit-major-mode-setup)
 
     ;; Enable outline-minor-mode for heading navigation and folding.
-    (outline-minor-mode 1)))
+    (outline-minor-mode 1))
+
+  ;; Added last: `font-lock-add-keywords' must run after
+  ;; `treesit-major-mode-setup' or it suppresses tree-sitter fontification.
+  (font-lock-add-keywords nil asciidoc--admonition-font-lock-keywords))
 
 ;;; Menu
 

--- a/test/asciidoc-mode-integration-test.el
+++ b/test/asciidoc-mode-integration-test.el
@@ -136,14 +136,15 @@ OCCURRENCE selects which match (default 1)."
       (expect (asciidoc-test-face-at-match "* Enable feature A")
               :to-equal 'font-lock-constant-face)))
 
-  (it "fontifies admonition content"
+  (it "fontifies the admonition label"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
-      ;; The admonition node starts at ": " after the keyword.
+      ;; The whole "NOTE:" label (keyword + colon) is highlighted via a
+      ;; font-lock keyword, since the grammar doesn't expose it as a node.
       (goto-char (point-min))
       (search-forward "NOTE:")
       (expect (get-text-property (match-beginning 0) 'face)
-              :to-be nil)
+              :to-equal 'font-lock-keyword-face)
       (expect (get-text-property (+ (match-beginning 0) 4) 'face)
               :to-equal 'font-lock-keyword-face)))
 

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -272,15 +272,34 @@
     (unless asciidoc-test-grammars-available
       (setq skip-reason "tree-sitter grammars not installed")))
 
-  (it "fontifies NOTE admonition content"
+  (it "fontifies the NOTE label as a keyword"
     (assume asciidoc-test-grammars-available skip-reason)
-    ;; The grammar doesn't include the keyword ("NOTE") in the
-    ;; admonition node -- fontification starts at the ": " separator.
+    ;; The whole "NOTE:" label is highlighted via a font-lock keyword.
     (with-fontified-asciidoc-buffer "= Title\n\nNOTE: This is a note.\n"
-      ;; Position of ":" after "NOTE" in the full buffer
-      (let ((pos (string-match ": This" (buffer-string))))
+      (let ((pos (string-match "NOTE:" (buffer-string))))
+        ;; the keyword itself
         (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'font-lock-keyword-face)))))
+                :to-equal 'font-lock-keyword-face)
+        ;; the trailing colon
+        (expect (asciidoc-test-face-at (+ 1 pos 4))
+                :to-equal 'font-lock-keyword-face))))
+
+  (it "does not clobber inline markup in the admonition body"
+    (assume asciidoc-test-grammars-available skip-reason)
+    ;; Inline `code` inside an admonition body must still be fontified as
+    ;; monospace, not overridden by the admonition label highlighting.
+    (with-fontified-asciidoc-buffer "= Title\n\nNOTE: see `code` here.\n"
+      (let ((pos (string-match "`code`" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ pos))
+                :to-equal 'font-lock-string-face))))
+
+  (it "recognizes all admonition labels"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (dolist (label '("NOTE" "TIP" "IMPORTANT" "CAUTION" "WARNING"))
+      (with-fontified-asciidoc-buffer (format "= Title\n\n%s: body.\n" label)
+        (let ((pos (string-match label (buffer-string))))
+          (expect (asciidoc-test-face-at (1+ pos))
+                  :to-equal 'font-lock-keyword-face))))))
 
 ;;; Imenu
 


### PR DESCRIPTION
The admonition rule faced the whole admonition node with `:override t`. Since the grammar drops the label word (`NOTE`) from the parse tree, this colored the body instead of the label and overrode inline `code`/links inside admonitions. Replaced it with a font-lock keyword that highlights just the label, so the body fontifies normally. Also fixes multi-line admonitions.

Found while checking `asciidoc-mode` against a real document (the adoc-mode README).