### PR TITLE
Restrict inline parser to inline-content ranges

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 
 === Bug Fixes
 
+* Restrict the inline parser to inline-content ranges. Previously it parsed the whole buffer, so block markup (e.g. a `*` list marker) could throw it into an error state that suppressed inline highlighting (`code`, links, etc.) for the rest of the buffer. Inline markup inside list items, table cells, and quote blocks now fontifies reliably.
 * Fix admonition fontification: highlight the label (e.g. `NOTE:`) instead of the body, so inline markup such as `code` and links inside an admonition is no longer clobbered. This also covers multi-line admonitions.
 
 == 0.2.0 (2026-06-02)

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -303,6 +303,30 @@ Install them with \\[asciidoc-install-grammars].
     (setq-local treesit-primary-parser
                 (car (treesit-parser-list nil 'asciidoc)))
 
+    ;; Restrict the inline parser to actual inline-content ranges.  The
+    ;; inline grammar is meant to parse a single inline span; run over the
+    ;; whole buffer it misreads block markup (e.g. `*' list markers) as
+    ;; emphasis and can produce an error spanning the rest of the buffer,
+    ;; which suppresses inline fontification.  Embedding it into the block
+    ;; parser via `treesit-range-rules' scopes it to the relevant text.
+    ;; The `line' / `table_cell_content' children are captured rather than
+    ;; their containers so block markers (`*', `.', `=') stay out of the
+    ;; inline ranges.
+    (setq-local treesit-range-settings
+                (treesit-range-rules
+                 :embed 'asciidoc-inline
+                 :host 'asciidoc
+                 '((paragraph (line) @cap)
+                   (admonition (line) @cap)
+                   (unordered_list_item (line) @cap)
+                   (ordered_list_item (line) @cap)
+                   (checked_list_item (line) @cap)
+                   (callout_list_item (line) @cap)
+                   (quoted_block (line) @cap)
+                   (table_cell (table_cell_content) @cap))))
+    (setq-local treesit-language-at-point-function
+                (lambda (_pos) 'asciidoc))
+
     ;; Font-lock
     (setq-local treesit-font-lock-settings asciidoc--font-lock-settings)
     (setq-local treesit-font-lock-feature-list

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -136,6 +136,51 @@
         (expect (asciidoc-test-face-at (+ (point-min) pos))
                 :to-equal 'font-lock-constant-face)))))
 
+;;; Font-lock: inline content inside blocks
+;;
+;; The inline parser is restricted to inline-content ranges via
+;; `treesit-range-settings'.  These tests guard that inline markup is
+;; still fontified inside the various containers, and that block markup
+;; no longer poisons inline fontification later in the buffer.
+
+(describe "Font-lock: inline content inside blocks"
+  :var (skip-reason)
+  (before-all
+    (unless asciidoc-test-grammars-available
+      (setq skip-reason "tree-sitter grammars not installed")))
+
+  (it "fontifies code inside an unordered list item"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (expect (asciidoc-test-mono-face "* item with `code` here\n" "`code`")
+            :to-equal 'font-lock-string-face))
+
+  (it "fontifies code inside a table cell"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (expect (asciidoc-test-mono-face "|===\n| cell `code` text\n|===\n" "`code`")
+            :to-equal 'font-lock-string-face))
+
+  (it "fontifies code inside a quote block"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (expect (asciidoc-test-mono-face "____\nquoted `code` text\n____\n" "`code`")
+            :to-equal 'font-lock-string-face))
+
+  (it "fontifies code after a stray list marker (no cascade)"
+    (assume asciidoc-test-grammars-available skip-reason)
+    ;; A `*' list marker with no matching `*' used to put the inline
+    ;; parser into an error state spanning the rest of the buffer.
+    (expect (asciidoc-test-mono-face
+             "* a lone bullet\n\nlater paragraph with `code`.\n" "`code`")
+            :to-equal 'font-lock-string-face))
+
+  (it "produces no inline parse error for a mixed document"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer
+        "= Title\n\n* one\n* two\n* three\n\nText `code` and more.\n"
+      (let ((parser (car (treesit-parser-list nil 'asciidoc-inline))))
+        (expect (string-match-p
+                 "ERROR" (treesit-node-string (treesit-parser-root-node parser)))
+                :to-be nil)))))
+
 ;;; Font-lock: blocks
 
 (describe "Font-lock: blocks"

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -30,5 +30,13 @@ CONTENT is inserted and BODY is evaluated after fontification."
   "Return the face at POS in the current buffer."
   (get-text-property pos 'face))
 
+(defun asciidoc-test-mono-face (text needle)
+  "Fontify TEXT in `asciidoc-mode' and return the face just inside NEEDLE.
+NEEDLE is a substring (e.g. a backtick-delimited code span); the face is
+read one character past its start."
+  (with-fontified-asciidoc-buffer text
+    (let ((pos (string-match needle (buffer-string))))
+      (asciidoc-test-face-at (1+ pos)))))
+
 (provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The inline parser was created over the whole buffer, but `asciidoc-inline` is meant to parse a single inline span. Fed block markup (e.g. a `*` list marker), it could enter an error state spanning the rest of the buffer, silently suppressing inline highlighting (`code`, links, etc.) past that point - very visible on real documents like the adoc-mode README.

Embeds the inline parser into the block parser via `treesit-range-rules` (the `mhtml-ts-mode` pattern), scoping it to the inline-content nodes. Captures the `line`/`table_cell_content` children rather than their containers, so block markers (`*`, `.`, `=`) stay out of the inline ranges. Inline markup inside list items, table cells, and quote blocks now fontifies reliably, with no cascade.

Found while checking the mode against the adoc-mode README.