### PR TITLE
Allow candidate-mode lists in asciidoc-code-lang-modes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 === New Features
 
-* Natively fontify `[source,LANG]` code blocks using the language's own major mode (like `markdown-mode`, `org-mode`, and `adoc-mode`). Configurable via `asciidoc-fontify-code-blocks-natively` (on by default, with a size cap), `asciidoc-code-lang-modes`, and `asciidoc-fontify-code-block-default-mode`.
+* Natively fontify `[source,LANG]` code blocks using the language's own major mode (like `markdown-mode`, `org-mode`, and `adoc-mode`). Configurable via `asciidoc-fontify-code-blocks-natively` (on by default, with a size cap), `asciidoc-code-lang-modes`, and `asciidoc-fontify-code-block-default-mode`. An `asciidoc-code-lang-modes` value may be a single mode or a list of candidate modes tried in order (e.g. `ocaml` maps to `neocaml-mode`, then `tuareg-mode`, then `caml-mode`), so a language uses the best available mode with no extra configuration.
 
 === Bug Fixes
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -78,14 +78,19 @@ blocks."
     ("bash" . sh-mode)
     ("shell" . sh-mode)
     ("elisp" . emacs-lisp-mode)
-    ("ocaml" . tuareg-mode)
+    ("ocaml" . (neocaml-mode tuareg-mode caml-mode))
     ("sqlite" . sql-mode))
   "Alist mapping AsciiDoc source languages to major modes.
 Used by native source block fontification when the major mode cannot be
 derived from the language name as LANG-mode.  The key is the language
-string as it appears in the block (e.g. the `ruby' in `[source,ruby]'),
-the value is the major mode symbol."
-  :type '(alist :key-type string :value-type function)
+string as it appears in the block (e.g. the `ruby' in `[source,ruby]').
+The value is either a single major mode or a list of candidate modes
+tried in order, the first defined one being used -- so a language can map
+to a preferred mode with fallbacks.  For example `ocaml' maps to
+`neocaml-mode', then `tuareg-mode', then `caml-mode'."
+  :type '(alist :key-type string
+                :value-type (choice (function :tag "Major mode")
+                                    (repeat (function :tag "Major mode"))))
   :package-version '(asciidoc-mode . "0.3.0"))
 
 (defcustom asciidoc-fontify-code-block-default-mode 'prog-mode
@@ -323,15 +328,18 @@ only for source blocks (a `source' or empty leading style)."
 
 (defun asciidoc--code-block-lang-mode (lang)
   "Return the major mode to fontify LANG, or nil if none is available.
-Consults `asciidoc-code-lang-modes', then LANG-mode, and honors any
+Consults `asciidoc-code-lang-modes' (whose value may be a single mode or
+a list of candidates tried in order), then LANG-mode, and honors any
 `major-mode-remap-alist' entry so tree-sitter modes are used when set."
   (let* ((down (downcase lang))
+         (norm (lambda (value) (if (listp value) value (list value))))
          (mode (seq-find
                 #'fboundp
-                (list (cdr (assoc lang asciidoc-code-lang-modes))
-                      (cdr (assoc down asciidoc-code-lang-modes))
-                      (intern (concat lang "-mode"))
-                      (intern (concat down "-mode"))))))
+                (append
+                 (funcall norm (cdr (assoc lang asciidoc-code-lang-modes)))
+                 (funcall norm (cdr (assoc down asciidoc-code-lang-modes)))
+                 (list (intern (concat lang "-mode"))
+                       (intern (concat down "-mode")))))))
     (when mode
       (if (fboundp 'major-mode-remap) (major-mode-remap mode) mode))))
 

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -362,6 +362,22 @@
   (it "returns nil when there is no language"
     (expect (asciidoc--code-block-language "source") :to-be nil)))
 
+(describe "Source block language mode resolution"
+  (it "resolves a single mapped mode"
+    (let ((asciidoc-code-lang-modes '(("foo" . emacs-lisp-mode))))
+      (expect (asciidoc--code-block-lang-mode "foo") :to-equal 'emacs-lisp-mode)))
+  (it "resolves a candidate list to the first available mode"
+    (let ((asciidoc-code-lang-modes
+           '(("foo" . (asciidoc-no-such-mode emacs-lisp-mode)))))
+      (expect (asciidoc--code-block-lang-mode "foo") :to-equal 'emacs-lisp-mode)))
+  (it "falls back to LANG-mode when not in the alist"
+    (let ((asciidoc-code-lang-modes nil))
+      (expect (asciidoc--code-block-lang-mode "emacs-lisp")
+              :to-equal 'emacs-lisp-mode)))
+  (it "returns nil when no candidate is available"
+    (let ((asciidoc-code-lang-modes '(("foo" . (asciidoc-no-such-mode)))))
+      (expect (asciidoc--code-block-lang-mode "foo") :to-be nil))))
+
 (describe "Native source block fontification"
   :var (skip-reason)
   (before-all


### PR DESCRIPTION
Following the same change in `adoc-mode`: an `asciidoc-code-lang-modes` value may now be a single major mode or a list of candidate modes tried in order, the first defined one winning.

This lets a language map to a preferred mode with graceful fallbacks and no user configuration. `ocaml` now maps to `(neocaml-mode tuareg-mode caml-mode)` - the modern tree-sitter mode when it's installed, falling back to tuareg/caml otherwise. Single-symbol values keep working unchanged.