### PR TITLE
Fix document-header fontification

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,14 @@
 
 == main (unreleased)
 
+=== Bug Fixes
+
+* Stop the document title face from bleeding onto the header's attribute lines. The grammar nests `:name: value` attribute entries inside the `document_title` node, so the whole header (not just the title) was rendered with the title face.
+
+=== New Features
+
+* Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
+
 == 0.3.0 (2026-06-03)
 
 === New Features

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -184,7 +184,12 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
    :language 'asciidoc
    :override t
    :feature 'title
-   '((document_title) @asciidoc-document-title-face
+   ;; The grammar nests the header's `document_attr' entries inside
+   ;; `document_title', so face only the title's marker and its own line --
+   ;; not the whole node, which would bleed the title face onto the
+   ;; `:name: value' attribute lines below the title.
+   '((document_title (title_h0_marker) @asciidoc-document-title-face)
+     (document_title (line) @asciidoc-document-title-face)
      (title1) @asciidoc-title-1-face
      (title2) @asciidoc-title-2-face
      (title3) @asciidoc-title-3-face
@@ -303,6 +308,17 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
   '(("^\\(?:NOTE\\|TIP\\|IMPORTANT\\|CAUTION\\|WARNING\\):"
      0 'font-lock-keyword-face t))
   "Font-lock keywords for paragraph-style admonition labels.")
+
+;;; Attribute references
+
+;; The inline grammar doesn't recognize attribute references (`{name}'
+;; expands to nothing), so highlight them with a font-lock keyword.  The
+;; nil override leaves existing faces (code blocks, strings) untouched, so
+;; e.g. a shell `${VAR}' inside a source block is not mistaken for one.
+(defvar asciidoc--attribute-reference-font-lock-keywords
+  '(("{\\(?:[a-zA-Z0-9_][a-zA-Z0-9_-]*\\)}"
+     0 'font-lock-variable-name-face nil))
+  "Font-lock keywords for inline attribute references like `{name}'.")
 
 ;;; Native source block fontification
 
@@ -528,6 +544,7 @@ Install them with \\[asciidoc-install-grammars].
   ;; string face, replacing it with native faces (see
   ;; `asciidoc--fontify-code-blocks').
   (font-lock-add-keywords nil asciidoc--admonition-font-lock-keywords)
+  (font-lock-add-keywords nil asciidoc--attribute-reference-font-lock-keywords)
   (font-lock-add-keywords nil '((asciidoc--fontify-code-blocks)) 'append))
 
 ;;; Menu

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -83,7 +83,20 @@
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "====== Section 5\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'asciidoc-title-5-face))))
+              :to-equal 'asciidoc-title-5-face)))
+
+  (it "does not bleed the title face onto header attribute lines"
+    (assume asciidoc-test-grammars-available skip-reason)
+    ;; The grammar nests document attributes inside `document_title'; the
+    ;; title face must not cover the `:name: value' lines below the title.
+    (with-fontified-asciidoc-buffer "= Title\n:author: Jane\n\nBody.\n"
+      (let ((pos (string-match ":author:" (buffer-string))))
+        ;; the attribute name is a variable, not part of the title
+        (expect (asciidoc-test-face-at (+ 1 pos 1))
+                :to-equal 'font-lock-variable-name-face)
+        ;; the leading ":" delimiter is not title-faced
+        (expect (asciidoc-test-face-at (1+ pos))
+                :not :to-equal 'asciidoc-document-title-face)))))
 
 ;;; Font-lock: comments
 
@@ -307,7 +320,16 @@
     (with-fontified-asciidoc-buffer ":author: Jane Doe\n"
       (let ((pos (string-match "Jane" (buffer-string))))
         (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'font-lock-string-face)))))
+                :to-equal 'font-lock-string-face))))
+
+  (it "highlights inline attribute references"
+    (assume asciidoc-test-grammars-available skip-reason)
+    ;; The grammar does not parse `{name}' references, so a font-lock
+    ;; keyword highlights them.
+    (with-fontified-asciidoc-buffer "= T\n\nSee {version} now.\n"
+      (let ((pos (string-match "{version}" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ pos))
+                :to-equal 'font-lock-variable-name-face)))))
 
 ;;; Font-lock: admonitions
 


### PR DESCRIPTION
Two font-lock fixes found while looking at the project's own README:

- **Title face bleed.** The grammar nests the header's `:name: value` attribute entries inside the `document_title` node, so facing the whole node painted those lines with the big title face (they looked like titles). Now only the title marker and its own line are faced.
- **Attribute references.** `{name}` references (e.g. `{url-repo}`) weren't highlighted at all - the grammar doesn't parse them. Added a font-lock keyword that highlights them, with a nil override so it doesn't clobber code blocks (a shell `${VAR}` inside a source block is left to the language mode).

Note: `{url}[label]` links whose URL is an attribute reference still aren't recognized as links - that needs grammar support (tracked upstream).