### PR TITLE
Fix fill-paragraph mangling lines with URLs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 
 === Bug Fixes
 
+* Fix `fill-paragraph` (`M-q`) mangling paragraphs that contain a URL. The `//` in `https://` was treated as a comment start, so continuation lines were indented and prefixed with `//`. AsciiDoc line comments only start at the beginning of a line, so `comment-start-skip` is now anchored accordingly.
 * Stop the document title face from bleeding onto the header's attribute lines. The grammar nests `:name: value` attribute entries inside the `document_title` node, so the whole header (not just the title) was rendered with the title face.
 
 === New Features

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -473,7 +473,11 @@ Install them with \\[asciidoc-install-grammars].
 
 \\{asciidoc-mode-map}"
   (setq-local comment-start "// ")
-  (setq-local comment-start-skip "//+\\s-*")
+  ;; AsciiDoc line comments only start at the beginning of a line, so
+  ;; anchor the skip regexp.  Otherwise the comment-aware filling sees the
+  ;; `//' in a URL like `https://...' mid-line and fills the paragraph with
+  ;; a bogus `//' prefix.
+  (setq-local comment-start-skip "^//+\\s-*")
 
   (when (asciidoc--ensure-grammars)
     ;; Create both parsers over the full buffer.

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -503,5 +503,17 @@
       (forward-sentence)
       (expect (looking-at "\nSecond") :to-be-truthy))))
 
+;;; Filling
+
+(describe "Filling"
+  (it "fills a paragraph containing a URL without a bogus comment prefix"
+    (with-asciidoc-buffer
+        "Visit https://example.com/a/b for more details about the project here.\n"
+      (setq-local fill-column 40)
+      (goto-char (point-min))
+      (fill-paragraph)
+      ;; The `//' inside the URL must not become a fill/comment prefix.
+      (expect (string-match-p "^[ \t]*//" (buffer-string)) :to-be nil))))
+
 (provide 'asciidoc-mode-test)
 ;;; asciidoc-mode-test.el ends here


### PR DESCRIPTION
`M-q` on a paragraph containing a URL produced broken output: the `//` in `https://` was picked up by the comment-aware filling, so continuation lines got indented and prefixed with `//`.

AsciiDoc line comments only start at the beginning of a line, so anchoring `comment-start-skip` to `^` fixes it. `comment-region`/`uncomment-region` still work (verified).