### PR TITLE
Add a font-lock smoke test over a construct-dense document

### DIFF
--- a/test/asciidoc-mode-smoke-test.el
+++ b/test/asciidoc-mode-smoke-test.el
@@ -1,0 +1,120 @@
+;;; asciidoc-mode-smoke-test.el --- Font-lock smoke test for asciidoc-mode -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; A smoke test that fontifies a large, construct-dense document
+;; (test/fixtures/showcase.adoc) and checks that `asciidoc-mode' handles
+;; it without error, produces a stable (idempotent) fontification, and
+;; actually applies the expected faces.  This guards against regressions
+;; that only show up on complex documents: runaway inline-parser state
+;; that swallows the rest of the buffer, under-fontification, faces
+;; bleeding across constructs, and errors in the font-lock keyword
+;; matchers.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'test-helper)
+
+(defvar asciidoc-test-grammars-available
+  (and (treesit-available-p)
+       (treesit-language-available-p 'asciidoc)
+       (treesit-language-available-p 'asciidoc-inline))
+  "Non-nil if both AsciiDoc tree-sitter grammars are installed.")
+
+(defvar asciidoc-test-showcase-file
+  (expand-file-name "fixtures/showcase.adoc"
+                    (file-name-directory (or load-file-name buffer-file-name)))
+  "Path to the construct-dense showcase fixture.")
+
+(describe "Font-lock smoke test"
+  :var (skip-reason)
+  (before-all
+    (unless asciidoc-test-grammars-available
+      (setq skip-reason "tree-sitter grammars not installed")))
+
+  (defun asciidoc-test--showcase-buffer ()
+    "Return a fontified `asciidoc-mode' buffer with the showcase document."
+    (let ((buf (generate-new-buffer " *asciidoc-showcase*")))
+      (with-current-buffer buf
+        (insert-file-contents asciidoc-test-showcase-file)
+        (asciidoc-mode)
+        (font-lock-ensure))
+      buf))
+
+  (it "fontifies the whole showcase document without error"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (let ((buf (asciidoc-test--showcase-buffer)))
+      (unwind-protect
+          (with-current-buffer buf
+            ;; re-fontifying an already-fontified buffer must not error either
+            (expect (font-lock-ensure) :not :to-throw)
+            (expect (> (point-max) 1000) :to-be-truthy))
+        (kill-buffer buf))))
+
+  (it "produces a stable (idempotent) fontification"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (let ((buf (asciidoc-test--showcase-buffer)))
+      (unwind-protect
+          (with-current-buffer buf
+            (cl-flet ((face-vector ()
+                        (let (acc (pos (point-min)))
+                          (while (< pos (point-max))
+                            (push (get-text-property pos 'face) acc)
+                            (setq pos (1+ pos)))
+                          (nreverse acc))))
+              (let ((faces-before (face-vector)))
+                (font-lock-flush)
+                (font-lock-ensure)
+                (expect (face-vector) :to-equal faces-before))))
+        (kill-buffer buf))))
+
+  (it "applies the expected faces across the document"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (let ((buf (asciidoc-test--showcase-buffer)))
+      (unwind-protect
+          (with-current-buffer buf
+            (let ((present (make-hash-table :test 'equal))
+                  (pos (point-min))
+                  missing)
+              (while (< pos (point-max))
+                (dolist (f (let ((v (get-text-property pos 'face)))
+                             (if (listp v) v (list v))))
+                  (when f (puthash f t present)))
+                (setq pos (1+ pos)))
+              (dolist (face '(asciidoc-document-title-face ; document title
+                              asciidoc-title-1-face        ; section titles
+                              asciidoc-title-2-face
+                              bold                          ; *bold*
+                              italic                        ; _italic_
+                              font-lock-string-face         ; `mono` / code bodies
+                              font-lock-warning-face        ; #highlight#
+                              font-lock-constant-face       ; list markers / links / xrefs
+                              font-lock-keyword-face        ; admonition labels
+                              font-lock-comment-face        ; // comments
+                              font-lock-delimiter-face      ; block / table delimiters
+                              font-lock-preprocessor-face   ; element attributes
+                              font-lock-variable-name-face  ; attribute names / references
+                              font-lock-function-call-face  ; macro names
+                              font-lock-type-face           ; block titles
+                              font-lock-doc-face))          ; author / revision lines
+                (unless (gethash face present) (push face missing)))
+              (expect missing :to-be nil)))
+        (kill-buffer buf))))
+
+  (it "fontifies a source block with its language major mode"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (let ((buf (asciidoc-test--showcase-buffer)))
+      (unwind-protect
+          (with-current-buffer buf
+            ;; the [source,emacs-lisp] block body should be natively fontified
+            (goto-char (point-min))
+            (search-forward "(defun greet")
+            (goto-char (match-beginning 0))
+            (search-forward "defun")
+            (expect (get-text-property (match-beginning 0) 'face)
+                    :to-equal 'font-lock-keyword-face))
+        (kill-buffer buf)))))
+
+(provide 'asciidoc-mode-smoke-test)
+;;; asciidoc-mode-smoke-test.el ends here

--- a/test/fixtures/showcase.adoc
+++ b/test/fixtures/showcase.adoc
@@ -1,0 +1,166 @@
+= Showcase AsciiDoc Document
+Bozhidar Batsov <bozhidar@example.com>
+v1.0, 2026-06-03: initial revision
+:toc: left
+:sample-attr: a reusable value
+
+This fixture exercises a broad cross-section of AsciiDoc constructs.  It is
+used by the font-lock smoke test to make sure a realistic, construct-dense
+document fontifies without error, stably, and with the expected faces.
+
+A reference to an attribute: {sample-attr}.
+
+== Inline formatting
+
+Constrained: *bold*, _italic_, `monospace`, and #highlight#.
+
+Unconstrained: **b**old, __i__talic, ##mark##ed.
+
+Passthroughs are not monospace: +plain text+ and ++unconstrained++, while a
++++raw+++ and $$literal$$ pass content through.
+
+Curved quotes: "`a quotation`" and '`an aside`'.
+
+Escapes stay literal: \*not bold* and \`not code`.
+
+Replacements: (C), (R), (TM), an ellipsis ..., and arrows -> => <- <=.
+
+A forced line break here +
+continues on the next line.
+
+== Sections
+
+=== Section level two
+
+==== Section level three
+
+===== Section level four
+
+====== Section level five
+
+[#custom-id]
+== Section with an id shorthand
+
+See <<custom-id>> and <<custom-id,a caption>> and xref:other.adoc[an xref].
+
+[[block-anchor]]
+A block anchor target, referenced via <<block-anchor>>.
+
+== Lists
+
+.An unordered list
+* level one
+** level two
+*** level three
+- a dash bullet
+
+.An ordered list
+. implicit one
+. implicit two
+.. implicit nested
+
+.A checklist
+* [ ] todo item
+* [x] done item
+
+== Admonitions
+
+NOTE: This is an admonition paragraph.
+
+[WARNING]
+====
+This is an admonition block with a delimited body.
+====
+
+== Delimited blocks
+
+.A listing block
+----
+plain listing, no language
+----
+
+.A Ruby source block
+[source,ruby]
+----
+def greet(name)
+  # say hello
+  puts "Hello, world"
+end
+----
+
+.An Emacs Lisp source block
+[source,emacs-lisp]
+----
+(defun greet (name)
+  (message "Hello, %s" name))
+----
+
+.A literal block
+....
+literal text, rendered verbatim
+....
+
+.A quote block
+[quote, Anonymous]
+____
+The body of a quotation.
+____
+
+.A sidebar
+****
+An aside in a sidebar.
+****
+
+.A passthrough block
+++++
+<custom-html>passed through</custom-html>
+++++
+
+.An open block
+--
+An open block body.
+--
+
+////
+A comment block that should be ignored entirely.
+////
+
+// a single-line comment
+
+== Tables
+
+.A small table
+[cols="1,1",options="header"]
+|===
+| Name | Value
+
+| alpha
+| one
+
+| beta
+| two
+|===
+
+== Macros
+
+A link: https://example.com/page[the docs] and a bare URL
+https://example.com/raw and an email contact@example.com.
+
+An inline image image:logo.png[Logo,32,32] and a block image:
+
+image::diagram.png[Architecture diagram]
+
+A footnote.footnote:[The footnote text.] and a UI macro kbd:[C-c C-c],
+a button btn:[OK], and a menu menu:File[Save As].
+
+Math via STEM: stem:[a^2 + b^2 = c^2].
+
+A passthrough macro: pass:[<b>raw</b>].
+
+== Breaks
+
+A thematic break:
+
+'''
+
+The end.


### PR DESCRIPTION
Adds `test/fixtures/showcase.adoc` (a realistic, construct-dense document) and a smoke test that fontifies it and asserts three invariants, in the spirit of adoc-mode's smoke test:

- fontifies without error (including on re-fontification),
- stable / idempotent fontification,
- the expected faces appear across the whole document (structural, inline, block, macro, table, and native source-block fontification).

This is a regression net for the class of issues that only show up on complex documents - runaway inline-parser state swallowing the rest of the buffer, under-fontification, face bleed, and keyword-matcher errors - several of which we hit recently.