### PR TITLE
Heading commands, org-style keybindings, and link/anchor faces

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,8 @@
 
 === New Features
 
+* Add heading commands `asciidoc-promote-heading` and `asciidoc-demote-heading` (add/remove a `=` marker), plus an org-style keymap: `M-left`/`M-right` promote/demote, `M-up`/`M-down` move a subtree, and `C-c C-n`/`C-c C-p`/`C-c C-f`/`C-c C-b`/`C-c C-u` for heading navigation. `TAB`/`S-TAB` now cycle heading visibility. Note that `M-left`/`M-right` shadow the default `left-word`/`right-word`.
+* Use dedicated, customizable faces for links (`asciidoc-link-face`), cross-references (`asciidoc-cross-reference-face`), and anchors (`asciidoc-anchor-face`) so they're visually distinct, instead of reusing generic font-lock faces.
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
 
 == 0.3.0 (2026-06-03)

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -49,6 +49,7 @@
 
 (require 'treesit)
 (require 'subr-x)
+(require 'outline)
 
 ;;; Customization
 
@@ -167,6 +168,21 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
   "Face for AsciiDoc level-5 section title (====== Title)."
   :group 'asciidoc)
 
+(defface asciidoc-link-face
+  '((t :inherit link))
+  "Face for links and link text (autolinks, URL labels)."
+  :group 'asciidoc)
+
+(defface asciidoc-cross-reference-face
+  '((t :inherit font-lock-constant-face))
+  "Face for internal cross-references (e.g. <<id>>)."
+  :group 'asciidoc)
+
+(defface asciidoc-anchor-face
+  '((t :inherit font-lock-type-face))
+  "Face for anchor definitions (e.g. [[id]] and [#id])."
+  :group 'asciidoc)
+
 ;;; Font-lock
 
 (defvar asciidoc--font-lock-settings
@@ -264,9 +280,9 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
 
    :language 'asciidoc-inline
    :feature 'inline-link
-   '((autolink) @font-lock-constant-face
-     (xref) @font-lock-constant-face
-     (uri_label) @link)
+   '((autolink) @asciidoc-link-face
+     (xref) @asciidoc-cross-reference-face
+     (uri_label) @asciidoc-link-face)
 
    :language 'asciidoc-inline
    :feature 'inline-macro
@@ -277,7 +293,7 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
 
    :language 'asciidoc-inline
    :feature 'inline-reference
-   '((id_assignment) @font-lock-preprocessor-face
+   '((id_assignment) @asciidoc-anchor-face
      (index_term) @font-lock-doc-face
      (index_term2) @font-lock-doc-face
      (intrinsic_attributes_pair) @font-lock-escape-face)
@@ -461,6 +477,37 @@ and always returns nil, doing its work as a side effect."
   "\\`\\(?:document_title\\|title[1-5]\\)\\'"
   "Regexp matching title node types for outline integration.")
 
+;;; Heading commands
+
+(defconst asciidoc--heading-regexp "^\\(=\\{1,6\\}\\)[ \t]"
+  "Regexp matching a one-line AsciiDoc heading.
+Group 1 is the run of leading `=' markers.")
+
+(defun asciidoc--heading-marker-bounds ()
+  "Return (BEG . END) of the current line's heading markers, or nil."
+  (save-excursion
+    (beginning-of-line)
+    (when (looking-at asciidoc--heading-regexp)
+      (cons (match-beginning 1) (match-end 1)))))
+
+(defun asciidoc-promote-heading ()
+  "Promote the heading on the current line by removing one `=' marker."
+  (interactive)
+  (let ((bounds (asciidoc--heading-marker-bounds)))
+    (cond ((null bounds) (user-error "Point is not on a heading"))
+          ((<= (- (cdr bounds) (car bounds)) 1)
+           (user-error "Already at the topmost heading level"))
+          (t (save-excursion (goto-char (car bounds)) (delete-char 1))))))
+
+(defun asciidoc-demote-heading ()
+  "Demote the heading on the current line by adding one `=' marker."
+  (interactive)
+  (let ((bounds (asciidoc--heading-marker-bounds)))
+    (cond ((null bounds) (user-error "Point is not on a heading"))
+          ((>= (- (cdr bounds) (car bounds)) 6)
+           (user-error "Already at the deepest heading level"))
+          (t (save-excursion (goto-char (car bounds)) (insert "="))))))
+
 ;;; Mode definition
 
 ;;;###autoload
@@ -539,7 +586,9 @@ Install them with \\[asciidoc-install-grammars].
 
     (treesit-major-mode-setup)
 
-    ;; Enable outline-minor-mode for heading navigation and folding.
+    ;; Enable outline-minor-mode for heading navigation and folding, with
+    ;; TAB/S-TAB cycling visibility on heading lines.
+    (setq-local outline-minor-mode-cycle t)
     (outline-minor-mode 1))
 
   ;; Added last: `font-lock-add-keywords' must run after
@@ -550,6 +599,19 @@ Install them with \\[asciidoc-install-grammars].
   (font-lock-add-keywords nil asciidoc--admonition-font-lock-keywords)
   (font-lock-add-keywords nil asciidoc--attribute-reference-font-lock-keywords)
   (font-lock-add-keywords nil '((asciidoc--fontify-code-blocks)) 'append))
+
+;;; Keymap
+
+;; Heading-oriented bindings modelled on `org-mode' / `adoc-mode'.
+(keymap-set asciidoc-mode-map "M-<left>" #'asciidoc-promote-heading)
+(keymap-set asciidoc-mode-map "M-<right>" #'asciidoc-demote-heading)
+(keymap-set asciidoc-mode-map "M-<up>" #'outline-move-subtree-up)
+(keymap-set asciidoc-mode-map "M-<down>" #'outline-move-subtree-down)
+(keymap-set asciidoc-mode-map "C-c C-n" #'outline-next-visible-heading)
+(keymap-set asciidoc-mode-map "C-c C-p" #'outline-previous-visible-heading)
+(keymap-set asciidoc-mode-map "C-c C-f" #'outline-forward-same-level)
+(keymap-set asciidoc-mode-map "C-c C-b" #'outline-backward-same-level)
+(keymap-set asciidoc-mode-map "C-c C-u" #'outline-up-heading)
 
 ;;; Menu
 
@@ -575,8 +637,8 @@ Install them with \\[asciidoc-install-grammars].
      ["Hide Body" outline-hide-body]
      ["Hide Other" outline-hide-other])
     ("Headings"
-     ["Promote Subtree" outline-promote]
-     ["Demote Subtree" outline-demote]
+     ["Promote Heading" asciidoc-promote-heading]
+     ["Demote Heading" asciidoc-demote-heading]
      ["Move Subtree Up" outline-move-subtree-up]
      ["Move Subtree Down" outline-move-subtree-down]
      "---"

--- a/test/asciidoc-mode-smoke-test.el
+++ b/test/asciidoc-mode-smoke-test.el
@@ -89,7 +89,10 @@
                               italic                        ; _italic_
                               font-lock-string-face         ; `mono` / code bodies
                               font-lock-warning-face        ; #highlight#
-                              font-lock-constant-face       ; list markers / links / xrefs
+                              font-lock-constant-face       ; list markers
+                              asciidoc-link-face            ; links / URL labels
+                              asciidoc-cross-reference-face ; <<id>> cross-references
+                              asciidoc-anchor-face          ; [[id]] anchors
                               font-lock-keyword-face        ; admonition labels
                               font-lock-comment-face        ; // comments
                               font-lock-delimiter-face      ; block / table delimiters

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -147,7 +147,21 @@
     (with-fontified-asciidoc-buffer "Visit https://example.com for details.\n"
       (let ((pos (string-match "https" "Visit https://example.com for details.")))
         (expect (asciidoc-test-face-at (+ (point-min) pos))
-                :to-equal 'font-lock-constant-face)))))
+                :to-equal 'asciidoc-link-face))))
+
+  (it "fontifies cross-references distinctly from links"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "= T\n\nSee <<some-id>> for details.\n"
+      (let ((pos (string-match "<<some-id>>" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ pos))
+                :to-equal 'asciidoc-cross-reference-face))))
+
+  (it "fontifies anchors with the anchor face"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "= T\n\n[[my-anchor]] target.\n"
+      (let ((pos (string-match "\\[\\[my-anchor" (buffer-string))))
+        (expect (asciidoc-test-face-at (+ pos 2))
+                :to-equal 'asciidoc-anchor-face)))))
 
 ;;; Font-lock: inline content inside blocks
 ;;
@@ -514,6 +528,52 @@
       (fill-paragraph)
       ;; The `//' inside the URL must not become a fill/comment prefix.
       (expect (string-match-p "^[ \t]*//" (buffer-string)) :to-be nil))))
+
+;;; Heading commands
+
+(describe "Heading commands"
+  (cl-flet ((line-after (text cmd)
+              (with-asciidoc-buffer text
+                (goto-char (point-min))
+                (funcall cmd)
+                (buffer-substring-no-properties
+                 (line-beginning-position) (line-end-position)))))
+
+    (it "demotes a heading by adding a marker"
+      (expect (line-after "== Section\n" #'asciidoc-demote-heading)
+              :to-equal "=== Section"))
+
+    (it "promotes a heading by removing a marker"
+      (expect (line-after "=== Section\n" #'asciidoc-promote-heading)
+              :to-equal "== Section"))
+
+    (it "refuses to promote past the topmost level"
+      (with-asciidoc-buffer "= Title\n"
+        (goto-char (point-min))
+        (expect (asciidoc-promote-heading) :to-throw 'user-error)))
+
+    (it "refuses to demote past the deepest level"
+      (with-asciidoc-buffer "====== Section\n"
+        (goto-char (point-min))
+        (expect (asciidoc-demote-heading) :to-throw 'user-error)))
+
+    (it "errors when point is not on a heading"
+      (with-asciidoc-buffer "Just a paragraph.\n"
+        (goto-char (point-min))
+        (expect (asciidoc-promote-heading) :to-throw 'user-error)))))
+
+;;; Keymap
+
+(describe "Keymap"
+  (it "binds org-style heading keys"
+    (expect (keymap-lookup asciidoc-mode-map "M-<left>")
+            :to-be 'asciidoc-promote-heading)
+    (expect (keymap-lookup asciidoc-mode-map "M-<right>")
+            :to-be 'asciidoc-demote-heading)
+    (expect (keymap-lookup asciidoc-mode-map "C-c C-n")
+            :to-be 'outline-next-visible-heading)
+    (expect (keymap-lookup asciidoc-mode-map "C-c C-u")
+            :to-be 'outline-up-heading)))
 
 (provide 'asciidoc-mode-test)
 ;;; asciidoc-mode-test.el ends here


### PR DESCRIPTION
Addresses three things noticed in real use:

**Structural editing.** New `asciidoc-promote-heading` / `asciidoc-demote-heading` add/remove a `=` marker on one-line headings (bounded at top/deepest levels). The menu's old `outline-promote`/`outline-demote` entries were effectively broken - on an AsciiDoc `== heading` they *prompted* for the new heading text instead of editing markers - and are now repointed to these.

**Org-style keybindings.** `M-left`/`M-right` promote/demote, `M-up`/`M-down` move a subtree, `C-c C-n`/`C-c C-p`/`C-c C-f`/`C-c C-b`/`C-c C-u` navigate headings, and `TAB`/`S-TAB` cycle visibility (mirrors `adoc-mode`/org). Note: `M-left`/`M-right` shadow the default word-motion, as in org.

**Dedicated faces.** Links, cross-references, and anchors used to share generic `font-lock-*` faces (external links and `<<id>>` were identical). Now `asciidoc-link-face` (inherits the built-in `link`), `asciidoc-cross-reference-face`, and `asciidoc-anchor-face` make them distinct and customizable.

Tests for the commands, keymap, and the three faces; smoke-test face set updated. (The mode menu itself was already correct - it renders fine in `emacs -Q`.)