### PR TITLE
Fontify role spans and description lists

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
 * Underline navigable references (links, cross-references) when the mouse hovers over them, via the new `asciidoc-link-mouse-face`.
 * Highlight custom-style role spans (`[.role]#text#`). The role names get the preprocessor face (like a block `[.role]` attribute list) and the span text is left to carry the role's own styling, instead of the mark/highlight face.
+* Highlight description (labeled) lists (`term:: definition`). The term gets the keyword face and the `::`/`:::` marker the constant face used for other list markers; inline markup inside the definition is fontified too.
 
 == 0.3.0 (2026-06-03)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@
 * Add heading commands `asciidoc-promote-heading` and `asciidoc-demote-heading` (add/remove a `=` marker), plus an org-style keymap: `M-left`/`M-right` promote/demote, `M-up`/`M-down` move a subtree, and `C-c C-n`/`C-c C-p`/`C-c C-f`/`C-c C-b`/`C-c C-u` for heading navigation. `TAB`/`S-TAB` now cycle heading visibility. Note that `M-left`/`M-right` shadow the default `left-word`/`right-word`.
 * Use dedicated, customizable faces for links (`asciidoc-link-face`), cross-references (`asciidoc-cross-reference-face`), and anchors (`asciidoc-anchor-face`) so they're visually distinct, instead of reusing generic font-lock faces.
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
+* Underline navigable references (links, cross-references) when the mouse hovers over them, via the new `asciidoc-link-mouse-face`.
 
 == 0.3.0 (2026-06-03)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@
 * Use dedicated, customizable faces for links (`asciidoc-link-face`), cross-references (`asciidoc-cross-reference-face`), and anchors (`asciidoc-anchor-face`) so they're visually distinct, instead of reusing generic font-lock faces.
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
 * Underline navigable references (links, cross-references) when the mouse hovers over them, via the new `asciidoc-link-mouse-face`.
+* Highlight custom-style role spans (`[.role]#text#`). The role names get the preprocessor face (like a block `[.role]` attribute list) and the span text is left to carry the role's own styling, instead of the mark/highlight face.
 
 == 0.3.0 (2026-06-03)
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -384,6 +384,17 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
      (subscript) @asciidoc--fontify-raised-span
      (passthrough) @font-lock-string-face)
 
+   ;; A custom-style span (`[.role]#text#') reuses the `highlight' node for
+   ;; its content, so the blanket rule above would render it with the
+   ;; mark/highlight face.  Override it: the role itself is markup (like a
+   ;; block `[.role]' attribute list, which uses the preprocessor face), and
+   ;; the span text carries the role's own styling, so leave it unfaced.
+   :language 'asciidoc-inline
+   :override t
+   :feature 'inline-markup
+   '((roled_text (role) @font-lock-preprocessor-face)
+     (roled_text (highlight) @default))
+
    :language 'asciidoc-inline
    :feature 'inline-link
    '((autolink) @asciidoc--fontify-reference

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -179,6 +179,11 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
   "Face for links and link text (autolinks, URL labels)."
   :group 'asciidoc)
 
+(defface asciidoc-link-mouse-face
+  '((t :inherit highlight :underline t))
+  "Face used to highlight a navigable reference under the mouse pointer."
+  :group 'asciidoc)
+
 (defface asciidoc-cross-reference-face
   '((t :inherit font-lock-constant-face))
   "Face for internal cross-references (e.g. <<id>>)."
@@ -278,7 +283,7 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
         (add-text-properties
          beg fin
          (list 'keymap asciidoc-reference-map
-               'mouse-face 'highlight
+               'mouse-face 'asciidoc-link-mouse-face
                'follow-link t
                'help-echo "mouse-1/RET: follow reference"))))))
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -352,7 +352,11 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
      (unordered_list_marker) @font-lock-constant-face
      (checked_list_marker) @font-lock-constant-face
      (callout_list_marker) @font-lock-constant-face
-     (callout_marker) @font-lock-constant-face)
+     (callout_marker) @font-lock-constant-face
+     ;; Description list (`term:: definition'): the term is a label, the
+     ;; `::'/`:::' separator a marker like the other list markers.
+     (description_list_item (term) @font-lock-keyword-face)
+     (description_marker) @font-lock-constant-face)
 
    :language 'asciidoc
    :override t
@@ -1184,6 +1188,7 @@ Install them with \\[asciidoc-install-grammars].
                    (ordered_list_item (line) @cap)
                    (checked_list_item (line) @cap)
                    (callout_list_item (line) @cap)
+                   (description_list_item (line) @cap)
                    (quoted_block (line) @cap)
                    (table_cell (table_cell_content) @cap)
                    (csv_record (table_cell_content) @cap)

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -204,7 +204,28 @@
     (with-fontified-asciidoc-buffer "= T\n\n[[my-anchor]] target.\n"
       (let ((pos (string-match "\\[\\[my-anchor" (buffer-string))))
         (expect (asciidoc-test-face-at (+ pos 2))
-                :to-equal 'asciidoc-anchor-face)))))
+                :to-equal 'asciidoc-anchor-face))))
+
+  (it "fontifies a role name on a custom-style span"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "A [.underline]#styled# word.\n"
+      (let ((role (string-match "underline" (buffer-string)))
+            (text (string-match "styled" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ role))
+                :to-equal 'font-lock-preprocessor-face)
+        ;; the span text carries the role's styling, so it stays unfaced
+        ;; instead of inheriting the highlight/mark face
+        (expect (asciidoc-test-face-at (1+ text)) :to-equal 'default))))
+
+  (it "fontifies multiple roles on an unconstrained span"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "A [.big.bold]##word## here.\n"
+      (let ((big (string-match "big" (buffer-string)))
+            (bold (string-match "bold" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ big))
+                :to-equal 'font-lock-preprocessor-face)
+        (expect (asciidoc-test-face-at (1+ bold))
+                :to-equal 'font-lock-preprocessor-face)))))
 
 ;;; Font-lock: inline content inside blocks
 ;;

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -671,7 +671,16 @@
     (with-fontified-asciidoc-buffer "[[target]] x\n\nSee <<target>> now.\n"
       (let ((pos (+ (point-min) (string-match "<<target" (buffer-string)))))
         (expect (get-text-property pos 'keymap)
-                :to-equal asciidoc-reference-map)))))
+                :to-equal asciidoc-reference-map))))
+
+  (it "underlines reference text under the mouse pointer"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "[[target]] x\n\nSee <<target>> now.\n"
+      (let ((pos (+ (point-min) (string-match "<<target" (buffer-string)))))
+        (expect (get-text-property pos 'mouse-face)
+                :to-equal 'asciidoc-link-mouse-face)
+        (expect (face-attribute 'asciidoc-link-mouse-face :underline nil t)
+                :to-be-truthy)))))
 
 ;;; Section id generation
 

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -400,6 +400,29 @@
       (let ((pos (string-match "_def" (buffer-string))))
         (expect (asciidoc-test-face-at (+ (point-min) pos)) :to-equal 'italic)))))
 
+;;; Font-lock: description lists
+
+(describe "Font-lock: description lists"
+  :var (skip-reason)
+  (before-all
+    (unless asciidoc-test-grammars-available
+      (setq skip-reason "tree-sitter grammars not installed")))
+
+  (it "fontifies the term and the `::' marker distinctly"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "CPU:: The brain.\n"
+      (expect (asciidoc-test-face-at (point-min))
+              :to-equal 'font-lock-keyword-face)
+      (let ((marker (string-match "::" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ marker))
+                :to-equal 'font-lock-constant-face))))
+
+  (it "fontifies inline markup inside a description definition"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "CPU:: The *brain* of it.\n"
+      (let ((pos (string-match "\\*brain" (buffer-string))))
+        (expect (asciidoc-test-face-at (+ (point-min) pos)) :to-equal 'bold)))))
+
 ;;; Font-lock: attributes
 
 (describe "Font-lock: attributes"


### PR DESCRIPTION
Two new constructs landed in the tree-sitter-asciidoc grammar (upstream PRs #87 and #88), so this wires up highlighting for them:

- Role spans `[.role]#text#` - role names get the preprocessor face (like a block `[.role]` attribute list); the inner span stays neutral instead of inheriting the highlight/mark face, since the role carries its own styling.
- Description lists `term:: definition` - the term gets the keyword face, the `::`/`:::` marker the constant face used for other list markers, and the definition body is added to the inline included-ranges so markup inside it fontifies.

Also folds in a small earlier change: navigable references now underline (not just highlight) on mouse hover, via a new `asciidoc-link-mouse-face`.

All three are separate commits. 157 specs pass.