### PR TITLE
Align inline faces with adoc-mode

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,8 +13,10 @@
 * Use dedicated, customizable faces for links (`asciidoc-link-face`), cross-references (`asciidoc-cross-reference-face`), and anchors (`asciidoc-anchor-face`) so they're visually distinct, instead of reusing generic font-lock faces.
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
 * Underline navigable references (links, cross-references) when the mouse hovers over them, via the new `asciidoc-link-mouse-face`.
-* Highlight custom-style role spans (`[.role]#text#`). The role names get the preprocessor face (like a block `[.role]` attribute list) and the span text is left to carry the role's own styling, instead of the mark/highlight face.
+* Highlight custom-style role spans (`[.role]#text#`). The role names get the preprocessor face (like a block `[.role]` attribute list). A known role applies its actual styling to the span text via the new `asciidoc-role-face-alist` (`underline`, `line-through`, `overline` out of the box); an unrecognized role leaves the text neutral. This mirrors `adoc-mode`.
 * Highlight description (labeled) lists (`term:: definition`). The term gets the keyword face and the `::`/`:::` marker the constant face used for other list markers; inline markup inside the definition is fontified too.
+* Use a dedicated `asciidoc-code-face` for inline `+`code`+` and listing block bodies. It inherits `fixed-pitch`, so code renders monospaced even under a variable-pitch default, matching `adoc-mode`.
+* Render highlighted spans (`#text#`) with the new `asciidoc-highlight-face` (inheriting `highlight`, typically a yellow background) instead of the warning face, matching Asciidoctor's marked-text output and `adoc-mode`.
 
 == 0.3.0 (2026-06-03)
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -230,6 +230,35 @@ Link text inside `[...]' uses `asciidoc-link-face' instead."
   "Face for footnote body text."
   :group 'asciidoc)
 
+(defface asciidoc-code-face
+  '((t :inherit (font-lock-string-face fixed-pitch)))
+  "Face for inline monospace text and listing block bodies.
+Inherits `fixed-pitch' so code renders in a monospaced font even when
+the buffer uses a variable-pitch default."
+  :group 'asciidoc)
+
+(defface asciidoc-highlight-face
+  '((t :inherit highlight))
+  "Face for highlighted/marked spans (e.g. `#text#').
+Asciidoctor renders a hash-delimited span with the default `highlight'
+style (typically a yellow background)."
+  :group 'asciidoc)
+
+(defface asciidoc-strike-through-face
+  '((t :strike-through t))
+  "Face for strike-through role spans (`[.line-through]#text#')."
+  :group 'asciidoc)
+
+(defface asciidoc-underline-face
+  '((t :underline t))
+  "Face for underline role spans (`[.underline]#text#')."
+  :group 'asciidoc)
+
+(defface asciidoc-overline-face
+  '((t :overline t))
+  "Face for overline role spans (`[.overline]#text#')."
+  :group 'asciidoc)
+
 (defcustom asciidoc-superscript-raise 0.4
   "How far to raise superscript text, as a fraction of line height.
 Applied as a `display' \\='(raise ...) property on top of
@@ -262,6 +291,36 @@ font-lock rule."
     (when (< beg fin)
       (treesit-fontify-with-override beg fin face override)
       (put-text-property beg fin 'display (list 'raise raise)))))
+
+(defcustom asciidoc-role-face-alist
+  '(("line-through" . asciidoc-strike-through-face)
+    ("underline"    . asciidoc-underline-face)
+    ("overline"     . asciidoc-overline-face))
+  "Alist mapping AsciiDoc role names to faces for custom-style spans.
+Recognised inside `[.role]#text#' (and the unconstrained `##' variant).
+A span whose role is not listed keeps the default face."
+  :type '(alist :key-type (string :tag "Role name")
+                :value-type (face :tag "Face"))
+  :group 'asciidoc)
+
+(defun asciidoc--fontify-roled-span (node override start end &rest _)
+  "Style the custom-style span NODE according to its role.
+A role listed in `asciidoc-role-face-alist' (e.g. `underline') applies its
+face to the span text.  An unrecognised role leaves the text unstyled,
+since the span reuses the `highlight' node and would otherwise inherit the
+mark face.  START, END and OVERRIDE come from the font-lock rule."
+  (let* ((parent (treesit-node-parent node))
+         (face (seq-some
+                (lambda (role)
+                  (cdr (assoc (treesit-node-text role t)
+                              asciidoc-role-face-alist)))
+                (treesit-filter-child
+                 parent
+                 (lambda (c) (equal (treesit-node-type c) "role")))))
+         (beg (max start (treesit-node-start node)))
+         (fin (min end (treesit-node-end node))))
+    (when (< beg fin)
+      (treesit-fontify-with-override beg fin (or face 'default) override))))
 
 (defvar-keymap asciidoc-reference-map
   :doc "Keymap active on the text of a navigable reference.
@@ -317,7 +376,7 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
    :language 'asciidoc
    :override t
    :feature 'block
-   '((listing_block_body) @font-lock-string-face
+   '((listing_block_body) @asciidoc-code-face
      (literal_block_body) @font-lock-string-face
      (ident_block_line) @font-lock-string-face
      (block_title) @font-lock-type-face
@@ -382,22 +441,23 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
    :feature 'inline-markup
    '((emphasis) @bold
      (ltalic) @italic
-     (monospace) @font-lock-string-face
-     (highlight) @font-lock-warning-face
+     (monospace) @asciidoc-code-face
+     (highlight) @asciidoc-highlight-face
      (superscript) @asciidoc--fontify-raised-span
      (subscript) @asciidoc--fontify-raised-span
      (passthrough) @font-lock-string-face)
 
    ;; A custom-style span (`[.role]#text#') reuses the `highlight' node for
-   ;; its content, so the blanket rule above would render it with the
-   ;; mark/highlight face.  Override it: the role itself is markup (like a
-   ;; block `[.role]' attribute list, which uses the preprocessor face), and
-   ;; the span text carries the role's own styling, so leave it unfaced.
+   ;; its content, so the blanket rule above would render it with the mark
+   ;; face.  Override it: the role itself is markup (like a block `[.role]'
+   ;; attribute list, which uses the preprocessor face), and the span text
+   ;; takes the role's own styling (underline, strike-through, ...) when the
+   ;; role is known, otherwise stays neutral.
    :language 'asciidoc-inline
    :override t
    :feature 'inline-markup
    '((roled_text (role) @font-lock-preprocessor-face)
-     (roled_text (highlight) @default))
+     (roled_text (highlight) @asciidoc--fontify-roled-span))
 
    :language 'asciidoc-inline
    :feature 'inline-link

--- a/test/asciidoc-mode-integration-test.el
+++ b/test/asciidoc-mode-integration-test.el
@@ -86,13 +86,13 @@ OCCURRENCE selects which match (default 1)."
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "`monospace`")
-              :to-equal 'font-lock-string-face)))
+              :to-equal 'asciidoc-code-face)))
 
   (it "fontifies listing block body"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "def hello")
-              :to-equal 'font-lock-string-face)))
+              :to-equal 'asciidoc-code-face)))
 
   (it "fontifies indented literal block"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -190,10 +190,10 @@ OCCURRENCE selects which match (default 1)."
   (it "listing block body overrides inline misparse"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
-      ;; Code inside a listing block should get string face even if
+      ;; Code inside a listing block should get the code face even if
       ;; the inline parser sees emphasis markers.
       (expect (asciidoc-test-face-at-match "def hello")
-              :to-equal 'font-lock-string-face))))
+              :to-equal 'asciidoc-code-face))))
 
 ;;; Navigation integration
 

--- a/test/asciidoc-mode-smoke-test.el
+++ b/test/asciidoc-mode-smoke-test.el
@@ -87,8 +87,9 @@
                               asciidoc-title-2-face
                               bold                          ; *bold*
                               italic                        ; _italic_
-                              font-lock-string-face         ; `mono` / code bodies
-                              font-lock-warning-face        ; #highlight#
+                              asciidoc-code-face            ; `mono` / listing bodies
+                              font-lock-string-face         ; literal / passthrough bodies
+                              asciidoc-highlight-face       ; #highlight#
                               font-lock-constant-face       ; list markers
                               asciidoc-link-face            ; URL labels
                               asciidoc-url-face             ; URLs / email targets

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -140,7 +140,7 @@
     (with-fontified-asciidoc-buffer "some `mono` text\n"
       (let ((pos (string-match "`mono" "some `mono` text")))
         (expect (asciidoc-test-face-at (+ (point-min) pos))
-                :to-equal 'font-lock-string-face))))
+                :to-equal 'asciidoc-code-face))))
 
   (it "fontifies superscript text and raises it"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -206,15 +206,29 @@
         (expect (asciidoc-test-face-at (+ pos 2))
                 :to-equal 'asciidoc-anchor-face))))
 
-  (it "fontifies a role name on a custom-style span"
+  (it "fontifies a highlighted span with the highlight face"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "A #marked# word.\n"
+      (let ((pos (string-match "marked" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ pos))
+                :to-equal 'asciidoc-highlight-face))))
+
+  (it "fontifies a role name and applies a known role's styling"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "A [.underline]#styled# word.\n"
       (let ((role (string-match "underline" (buffer-string)))
             (text (string-match "styled" (buffer-string))))
         (expect (asciidoc-test-face-at (1+ role))
                 :to-equal 'font-lock-preprocessor-face)
-        ;; the span text carries the role's styling, so it stays unfaced
-        ;; instead of inheriting the highlight/mark face
+        ;; a known role (underline) styles the span text accordingly
+        (expect (asciidoc-test-face-at (1+ text))
+                :to-equal 'asciidoc-underline-face))))
+
+  (it "leaves an unknown role's span unstyled"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "A [.bogus]#plain# word.\n"
+      (let ((text (string-match "plain" (buffer-string))))
+        ;; no styling face, and crucially not the highlight/mark face
         (expect (asciidoc-test-face-at (1+ text)) :to-equal 'default))))
 
   (it "fontifies multiple roles on an unconstrained span"
@@ -243,17 +257,17 @@
   (it "fontifies code inside an unordered list item"
     (assume asciidoc-test-grammars-available skip-reason)
     (expect (asciidoc-test-mono-face "* item with `code` here\n" "`code`")
-            :to-equal 'font-lock-string-face))
+            :to-equal 'asciidoc-code-face))
 
   (it "fontifies code inside a table cell"
     (assume asciidoc-test-grammars-available skip-reason)
     (expect (asciidoc-test-mono-face "|===\n| cell `code` text\n|===\n" "`code`")
-            :to-equal 'font-lock-string-face))
+            :to-equal 'asciidoc-code-face))
 
   (it "fontifies code inside a quote block"
     (assume asciidoc-test-grammars-available skip-reason)
     (expect (asciidoc-test-mono-face "____\nquoted `code` text\n____\n" "`code`")
-            :to-equal 'font-lock-string-face))
+            :to-equal 'asciidoc-code-face))
 
   (it "fontifies code after a stray list marker (no cascade)"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -261,7 +275,7 @@
     ;; parser into an error state spanning the rest of the buffer.
     (expect (asciidoc-test-mono-face
              "* a lone bullet\n\nlater paragraph with `code`.\n" "`code`")
-            :to-equal 'font-lock-string-face))
+            :to-equal 'asciidoc-code-face))
 
   (it "produces no inline parse error for a mixed document"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -286,7 +300,7 @@
       (goto-char (point-min))
       (forward-line 1)
       (expect (asciidoc-test-face-at (point))
-              :to-equal 'font-lock-string-face)))
+              :to-equal 'asciidoc-code-face)))
 
   (it "fontifies indented literal blocks"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -481,7 +495,7 @@
     (with-fontified-asciidoc-buffer "= Title\n\nNOTE: see `code` here.\n"
       (let ((pos (string-match "`code`" (buffer-string))))
         (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'font-lock-string-face))))
+                :to-equal 'asciidoc-code-face))))
 
   (it "recognizes all admonition labels"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -541,14 +555,14 @@
         (expect (asciidoc-test-face-at (1+ pos))
                 :to-equal 'font-lock-keyword-face))))
 
-  (it "leaves the string face when fontification is disabled"
+  (it "leaves the code face when fontification is disabled"
     (assume asciidoc-test-grammars-available skip-reason)
     (let ((asciidoc-fontify-code-blocks-natively nil))
       (with-fontified-asciidoc-buffer
           "= T\n\n[source,emacs-lisp]\n----\n(defun foo () nil)\n----\n"
         (let ((pos (string-match "defun" (buffer-string))))
           (expect (asciidoc-test-face-at (1+ pos))
-                  :to-equal 'font-lock-string-face)))))
+                  :to-equal 'asciidoc-code-face)))))
 
   (it "respects the size cap"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -557,32 +571,32 @@
           "= T\n\n[source,emacs-lisp]\n----\n(defun foo () nil)\n----\n"
         (let ((pos (string-match "defun" (buffer-string))))
           (expect (asciidoc-test-face-at (1+ pos))
-                  :to-equal 'font-lock-string-face)))))
+                  :to-equal 'asciidoc-code-face)))))
 
   (it "does not natively fontify a plain listing block"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "= T\n\n----\n(defun foo () nil)\n----\n"
       (let ((pos (string-match "defun" (buffer-string))))
         (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'font-lock-string-face))))
+                :to-equal 'asciidoc-code-face))))
 
-  (it "keeps the string face for an unknown language"
+  (it "keeps the code face for an unknown language"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer
         "= T\n\n[source,nosuchlang]\n----\nplain text\n----\n"
       (let ((pos (string-match "plain" (buffer-string))))
         (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'font-lock-string-face))))
+                :to-equal 'asciidoc-code-face))))
 
   (it "does not recurse on a [source,asciidoc] block"
     (assume asciidoc-test-grammars-available skip-reason)
     ;; Resolving the language to `asciidoc-mode' itself must not re-enter
-    ;; native fontification; the body keeps the verbatim string face.
+    ;; native fontification; the body keeps the verbatim code face.
     (with-fontified-asciidoc-buffer
         "= T\n\n[source,asciidoc]\n----\n== Nested\n----\n"
       (let ((pos (string-match "Nested" (buffer-string))))
         (expect (asciidoc-test-face-at pos)
-                :to-equal 'font-lock-string-face)))))
+                :to-equal 'asciidoc-code-face)))))
 
 ;;; Imenu
 


### PR DESCRIPTION
asciidoc-mode and adoc-mode fontify the same documents, so users switching between them shouldn't be surprised by different colors. I audited both and fixed the inline constructs where asciidoc-mode looked wrong or surprising:

- *Highlighted spans* (`#text#`) used `font-lock-warning-face` - an ordinary mark rendered like an error. Now `asciidoc-highlight-face` (inherits `highlight`), matching Asciidoctor's marked-text output and adoc-mode.
- *Inline code and listing block bodies* used `font-lock-string-face`, which isn't monospaced. Now `asciidoc-code-face` (inherits `fixed-pitch`).
- *Role spans* (`[.role]#text#`) rendered neutral. Now known roles apply their real styling via `asciidoc-role-face-alist` (`underline`, `line-through`, `overline`); unknown roles stay neutral. Mirrors adoc-mode.

Larger philosophy differences (outline-based heading faces vs adoc-mode's scaled titles, plain vs tinted bold/italic) are left as-is on purpose - they're part of asciidoc-mode's tree-sitter/outline identity.

159 specs pass.