### PR TITLE
Fade structural markup into the background

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,9 +14,10 @@
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
 * Underline navigable references (links, cross-references) when the mouse hovers over them, via the new `asciidoc-link-mouse-face`.
 * Highlight custom-style role spans (`[.role]#text#`). The role names get the preprocessor face (like a block `[.role]` attribute list). A known role applies its actual styling to the span text via the new `asciidoc-role-face-alist` (`underline`, `line-through`, `overline` out of the box); an unrecognized role leaves the text neutral. This mirrors `adoc-mode`.
-* Highlight description (labeled) lists (`term:: definition`). The term gets the keyword face and the `::`/`:::` marker the constant face used for other list markers; inline markup inside the definition is fontified too.
+* Highlight description (labeled) lists (`term:: definition`). The term gets the keyword face and the `::`/`:::` marker fades like the other list markers; inline markup inside the definition is fontified too.
 * Use a dedicated `asciidoc-code-face` for inline `+`code`+` and listing block bodies. It inherits `fixed-pitch`, so code renders monospaced even under a variable-pitch default, matching `adoc-mode`.
 * Render highlighted spans (`#text#`) with the new `asciidoc-highlight-face` (inheriting `highlight`, typically a yellow background) instead of the warning face, matching Asciidoctor's marked-text output and `adoc-mode`.
+* Fade structural markup into the background with the new `asciidoc-markup-face` (inheriting `shadow`): block delimiters (`----`, `====`, `\|===`, ...) and list markers (`*`, `1.`, `::`) so the prose stands out, matching `adoc-mode` and `markdown-mode`. Meaningful tokens stay distinct: checklist boxes (`[x]`/`[ ]`) and callout numbers (`<1>`) keep the constant face.
 
 == 0.3.0 (2026-06-03)
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -259,6 +259,14 @@ style (typically a yellow background)."
   "Face for overline role spans (`[.overline]#text#')."
   :group 'asciidoc)
 
+(defface asciidoc-markup-face
+  '((t :inherit shadow))
+  "Face for structural markup that should fade into the background.
+Used for block delimiters (`----', `====', ...) and list markers (`*',
+`1.', `::').  Inherits `shadow' so the prose stands out, matching
+`adoc-mode' and the convention in `markdown-mode'."
+  :group 'asciidoc)
+
 (defcustom asciidoc-superscript-raise 0.4
   "How far to raise superscript text, as a fraction of line height.
 Applied as a `display' \\='(raise ...) property on top of
@@ -386,36 +394,40 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
    :language 'asciidoc
    :override t
    :feature 'delimiter
-   '((listing_block_start_marker) @font-lock-delimiter-face
-     (listing_block_end_marker) @font-lock-delimiter-face
-     (literal_block_marker) @font-lock-delimiter-face
-     (passthrough_block_marker) @font-lock-delimiter-face
-     (open_block_marker) @font-lock-delimiter-face
-     (quoted_block_start_marker) @font-lock-delimiter-face
-     (quoted_block_end_marker) @font-lock-delimiter-face
-     (delimited_block_start_marker) @font-lock-delimiter-face
-     (delimited_block_end_marker) @font-lock-delimiter-face)
+   '((listing_block_start_marker) @asciidoc-markup-face
+     (listing_block_end_marker) @asciidoc-markup-face
+     (literal_block_marker) @asciidoc-markup-face
+     (passthrough_block_marker) @asciidoc-markup-face
+     (open_block_marker) @asciidoc-markup-face
+     (quoted_block_start_marker) @asciidoc-markup-face
+     (quoted_block_end_marker) @asciidoc-markup-face
+     (delimited_block_start_marker) @asciidoc-markup-face
+     (delimited_block_end_marker) @asciidoc-markup-face)
 
    :language 'asciidoc
    :override t
    :feature 'table
-   '((table_block_marker) @font-lock-delimiter-face
-     (csv_table_block_marker) @font-lock-delimiter-face
-     (dsv_table_block_marker) @font-lock-delimiter-face
+   '((table_block_marker) @asciidoc-markup-face
+     (csv_table_block_marker) @asciidoc-markup-face
+     (dsv_table_block_marker) @asciidoc-markup-face
      (table_cell_attr) @font-lock-preprocessor-face)
 
    :language 'asciidoc
    :override t
    :feature 'list
-   '((ordered_list_marker) @font-lock-constant-face
-     (unordered_list_marker) @font-lock-constant-face
-     (checked_list_marker) @font-lock-constant-face
+   ;; List markers fade like other structural markup.  Tokens that carry
+   ;; meaning rather than just structure keep a distinct face: the checkbox
+   ;; state (`[x]'/`[ ]') and callout numbers (`<1>').
+   '((ordered_list_marker) @asciidoc-markup-face
+     (unordered_list_marker) @asciidoc-markup-face
+     (checked_list_marker_checked) @font-lock-constant-face
+     (checked_list_marker_unchecked) @font-lock-constant-face
      (callout_list_marker) @font-lock-constant-face
      (callout_marker) @font-lock-constant-face
      ;; Description list (`term:: definition'): the term is a label, the
      ;; `::'/`:::' separator a marker like the other list markers.
      (description_list_item (term) @font-lock-keyword-face)
-     (description_marker) @font-lock-constant-face)
+     (description_marker) @asciidoc-markup-face)
 
    :language 'asciidoc
    :override t

--- a/test/asciidoc-mode-integration-test.el
+++ b/test/asciidoc-mode-integration-test.el
@@ -128,13 +128,13 @@ OCCURRENCE selects which match (default 1)."
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match ". Download")
-              :to-equal 'font-lock-constant-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies unordered list markers"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "* Enable feature A")
-              :to-equal 'font-lock-constant-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies the admonition label"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -158,7 +158,7 @@ OCCURRENCE selects which match (default 1)."
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "|===")
-              :to-equal 'font-lock-delimiter-face))))
+              :to-equal 'asciidoc-markup-face))))
 
 ;;; Block-level override
 
@@ -172,13 +172,13 @@ OCCURRENCE selects which match (default 1)."
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "* Enable feature A")
-              :to-equal 'font-lock-constant-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "nested list markers override spurious emphasis"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
       (expect (asciidoc-test-face-at-match "** Nested item")
-              :to-equal 'font-lock-constant-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "headings after list markers are not affected by inline misparse"
     (assume asciidoc-test-grammars-available skip-reason)

--- a/test/asciidoc-mode-smoke-test.el
+++ b/test/asciidoc-mode-smoke-test.el
@@ -90,7 +90,7 @@
                               asciidoc-code-face            ; `mono` / listing bodies
                               font-lock-string-face         ; literal / passthrough bodies
                               asciidoc-highlight-face       ; #highlight#
-                              font-lock-constant-face       ; list markers
+                              font-lock-constant-face       ; checkboxes / callouts
                               asciidoc-link-face            ; URL labels
                               asciidoc-url-face             ; URLs / email targets
                               asciidoc-cross-reference-face ; <<id>> cross-references
@@ -99,7 +99,7 @@
                               asciidoc-metadata-value-face  ; :attr: values
                               font-lock-keyword-face        ; admonition labels
                               font-lock-comment-face        ; // comments
-                              font-lock-delimiter-face      ; block / table delimiters
+                              asciidoc-markup-face          ; block/table delimiters, list markers
                               font-lock-preprocessor-face   ; element attributes
                               font-lock-variable-name-face  ; {attribute} references
                               font-lock-function-call-face  ; macro names

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -338,37 +338,61 @@
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "----\ncode\n----\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies literal block delimiters"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "....\nlit\n....\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies passthrough block delimiters"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "++++\npass\n++++\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies open block delimiters"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "--\nopen\n--\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies quote block delimiters"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "____\nquote\n____\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies example block delimiters"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "====\nexample\n====\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face))))
+              :to-equal 'asciidoc-markup-face))))
+
+;;; Font-lock: list markers
+
+(describe "Font-lock: list markers"
+  :var (skip-reason)
+  (before-all
+    (unless asciidoc-test-grammars-available
+      (setq skip-reason "tree-sitter grammars not installed")))
+
+  (it "fades unordered and ordered markers into the markup face"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "* one\n"
+      (expect (asciidoc-test-face-at (point-min)) :to-equal 'asciidoc-markup-face))
+    (with-fontified-asciidoc-buffer ". one\n"
+      (expect (asciidoc-test-face-at (point-min)) :to-equal 'asciidoc-markup-face)))
+
+  (it "keeps the checkbox distinct while fading its bullet"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "* [x] done\n"
+      ;; the `*' bullet fades, but the `[x]' checkbox stays a meaningful token
+      (expect (asciidoc-test-face-at (point-min)) :to-equal 'asciidoc-markup-face)
+      (let ((box (string-match "\\[x\\]" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ box))
+                :to-equal 'font-lock-constant-face)))))
 
 ;;; Font-lock: tables
 
@@ -382,7 +406,7 @@
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "|===\n| A | B\n|===\n"
       (expect (asciidoc-test-face-at 1)
-              :to-equal 'font-lock-delimiter-face)))
+              :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies table cell format specifiers"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -395,12 +419,12 @@
   (it "fontifies the CSV table fence"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer ",===\nName,Age\n,===\n"
-      (expect (asciidoc-test-face-at 1) :to-equal 'font-lock-delimiter-face)))
+      (expect (asciidoc-test-face-at 1) :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies the DSV table fence"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer ":===\na:b:c\n:===\n"
-      (expect (asciidoc-test-face-at 1) :to-equal 'font-lock-delimiter-face)))
+      (expect (asciidoc-test-face-at 1) :to-equal 'asciidoc-markup-face)))
 
   (it "fontifies inline markup inside a CSV cell"
     (assume asciidoc-test-grammars-available skip-reason)
@@ -429,7 +453,7 @@
               :to-equal 'font-lock-keyword-face)
       (let ((marker (string-match "::" (buffer-string))))
         (expect (asciidoc-test-face-at (1+ marker))
-                :to-equal 'font-lock-constant-face))))
+                :to-equal 'asciidoc-markup-face))))
 
   (it "fontifies inline markup inside a description definition"
     (assume asciidoc-test-grammars-available skip-reason)


### PR DESCRIPTION
Block delimiters (`----`, `====`, `|===`) and list markers (`*`, `1.`, `::`) were rendered with colored faces (`font-lock-delimiter-face` / `font-lock-constant-face`), so AsciiDoc's structural punctuation competed with the prose. adoc-mode and markdown-mode both fade this markup. This adds `asciidoc-markup-face` (inherits `shadow`) and uses it for those markers.

Tokens that carry meaning rather than structure stay distinct: checklist boxes (`[x]`/`[ ]`) and callout numbers (`<1>`) keep the constant face, matching adoc-mode.

Part of aligning asciidoc-mode and adoc-mode so users switching between them aren't surprised. The companion change (plain bold/italic) lands in adoc-mode separately. 161 specs pass.