### PR TITLE
Align reference faces with org/markdown/adoc-mode

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 === New Features
 
 * Add heading commands `asciidoc-promote-heading` and `asciidoc-demote-heading` (add/remove a `=` marker), plus an org-style keymap: `M-left`/`M-right` promote/demote, `M-up`/`M-down` move a subtree, and `C-c C-n`/`C-c C-p`/`C-c C-f`/`C-c C-b`/`C-c C-u` for heading navigation. `TAB`/`S-TAB` now cycle heading visibility. Note that `M-left`/`M-right` shadow the default `left-word`/`right-word`.
-* Use dedicated, customizable faces for links (`asciidoc-link-face`), cross-references (`asciidoc-cross-reference-face`), and anchors (`asciidoc-anchor-face`) so they're visually distinct, instead of reusing generic font-lock faces.
+* Use dedicated, customizable faces for links (`asciidoc-link-face`), cross-references (`asciidoc-cross-reference-face`), and anchors (`asciidoc-anchor-face`), each independently customizable instead of reusing generic font-lock faces.
 * Highlight inline attribute references like `{name}`. The grammar doesn't recognize them, so they're fontified via a font-lock keyword; existing faces (code blocks, strings) are left untouched.
 * Underline navigable references (links, cross-references) when the mouse hovers over them, via the new `asciidoc-link-mouse-face`.
 * Highlight custom-style role spans (`[.role]#text#`). The role names get the preprocessor face (like a block `[.role]` attribute list). A known role applies its actual styling to the span text via the new `asciidoc-role-face-alist` (`underline`, `line-through`, `overline` out of the box); an unrecognized role leaves the text neutral. This mirrors `adoc-mode`.
@@ -18,6 +18,7 @@
 * Use a dedicated `asciidoc-code-face` for inline `+`code`+` and listing block bodies. It inherits `fixed-pitch`, so code renders monospaced even under a variable-pitch default, matching `adoc-mode`.
 * Render highlighted spans (`#text#`) with the new `asciidoc-highlight-face` (inheriting `highlight`, typically a yellow background) instead of the warning face, matching Asciidoctor's marked-text output and `adoc-mode`.
 * Fade structural markup into the background with the new `asciidoc-markup-face` (inheriting `shadow`): block delimiters (`----`, `====`, `\|===`, ...) and list markers (`*`, `1.`, `::`) so the prose stands out, matching `adoc-mode` and `markdown-mode`. Meaningful tokens stay distinct: checklist boxes (`[x]`/`[ ]`) and callout numbers (`<1>`) keep the constant face.
+* Align the reference faces with `org-mode`, `markdown-mode`, and `adoc-mode`. Cross-references (`<<id>>`) now inherit `link` (they're navigable, like an internal link) instead of the constant face; anchors (`[[id]]`) recede into `shadow` with an overline instead of the loud type face; and footnote bodies recede into the comment face.
 
 == 0.3.0 (2026-06-03)
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -185,13 +185,17 @@ Each entry has the form (LANG URL REVISION SOURCE-DIR CC C++).")
   :group 'asciidoc)
 
 (defface asciidoc-cross-reference-face
-  '((t :inherit font-lock-constant-face))
-  "Face for internal cross-references (e.g. <<id>>)."
+  '((t :inherit link))
+  "Face for internal cross-references (e.g. <<id>>).
+Inherits `link' (like the `org-mode' and `markdown-mode' link faces)
+since cross-references are navigable."
   :group 'asciidoc)
 
 (defface asciidoc-anchor-face
-  '((t :inherit font-lock-type-face))
-  "Face for anchor definitions (e.g. [[id]] and [#id])."
+  '((t :inherit shadow :overline t))
+  "Face for anchor definitions (e.g. [[id]] and [#id]).
+An anchor is a landmark rather than something you act on, so it fades
+like other markup (matching `adoc-mode'); the overline keeps it findable."
   :group 'asciidoc)
 
 (defface asciidoc-superscript-face
@@ -226,8 +230,10 @@ Link text inside `[...]' uses `asciidoc-link-face' instead."
   :group 'asciidoc)
 
 (defface asciidoc-footnote-text-face
-  '((t :inherit font-lock-doc-face))
-  "Face for footnote body text."
+  '((t :inherit font-lock-comment-face))
+  "Face for footnote body text.
+Footnote bodies are secondary text, so they recede into the comment face,
+matching `adoc-mode' and `markdown-mode'."
   :group 'asciidoc)
 
 (defface asciidoc-code-face

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -192,7 +192,7 @@
       (expect (asciidoc-test-face-at (+ (point-min) (string-match "a source" (buffer-string))))
               :to-equal 'asciidoc-footnote-text-face)))
 
-  (it "fontifies cross-references distinctly from links"
+  (it "fontifies cross-references with the cross-reference face"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "= T\n\nSee <<some-id>> for details.\n"
       (let ((pos (string-match "<<some-id>>" (buffer-string))))
@@ -205,6 +205,15 @@
       (let ((pos (string-match "\\[\\[my-anchor" (buffer-string))))
         (expect (asciidoc-test-face-at (+ pos 2))
                 :to-equal 'asciidoc-anchor-face))))
+
+  (it "gives reference faces their aligned looks"
+    ;; cross-references read as links (navigable); anchors recede but stay
+    ;; findable via an overline; footnote bodies recede into the comment face
+    (expect (face-attribute 'asciidoc-cross-reference-face :inherit nil t)
+            :to-equal 'link)
+    (expect (face-attribute 'asciidoc-anchor-face :overline nil t) :to-be-truthy)
+    (expect (face-attribute 'asciidoc-footnote-text-face :inherit nil t)
+            :to-equal 'font-lock-comment-face))
 
   (it "fontifies a highlighted span with the highlight face"
     (assume asciidoc-test-grammars-available skip-reason)


### PR DESCRIPTION
Bucket C of the cross-mode face audit. Three asciidoc faces were the odd ones out compared to how org-mode, markdown-mode, and adoc-mode treat the same constructs:

- *Cross-references* (`<<id>>`) used `font-lock-constant-face` with no link affordance, despite being navigable. Now inherit `link`, like `org-link` / `markdown-link-face` (and adoc-mode).
- *Anchors* (`[[id]]`) used a loud `font-lock-type-face`. An anchor is a landmark, not something you act on - now `shadow` + overline, so it recedes but stays findable (matching adoc-mode).
- *Footnote bodies* used `font-lock-doc-face`. Secondary text should recede - now the comment face, like adoc-mode and markdown-mode.

The other Bucket C items (`{name}`, footnote marker, admonition label, block title) were left as-is: asciidoc-mode already matches the ecosystem there, or there's no consensus to align to. 162 specs pass.