### PR TITLE
Render paragraph admonitions as color-coded callout blocks

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@
 * Render highlighted spans (`#text#`) with the new `asciidoc-highlight-face` (inheriting `highlight`, typically a yellow background) instead of the warning face, matching Asciidoctor's marked-text output and `adoc-mode`.
 * Fade structural markup into the background with the new `asciidoc-markup-face` (inheriting `shadow`): block delimiters (`----`, `====`, `\|===`, ...) and list markers (`*`, `1.`, `::`) so the prose stands out, matching `adoc-mode` and `markdown-mode`. Meaningful tokens stay distinct: checklist boxes (`[x]`/`[ ]`) and callout numbers (`<1>`) keep the constant face.
 * Align the reference faces with `org-mode`, `markdown-mode`, and `adoc-mode`. Cross-references (`<<id>>`) now inherit `link` (they're navigable, like an internal link) instead of the constant face; anchors (`[[id]]`) recede into `shadow` with an overline instead of the loud type face; and footnote bodies recede into the comment face.
+* Render paragraph admonitions (`NOTE:`, `TIP:`, `IMPORTANT:`, `CAUTION:`, `WARNING:`) as color-coded callout blocks, like Asciidoctor's rendered output. Each type gets its own label face and a subtle whole-block background (light/dark aware) that spans the admonition's body, including lines it wraps onto. The background can be turned off with `asciidoc-fontify-admonition-blocks`. Detection is tree-sitter-driven, so a `NOTE:`-looking line inside a code block isn't mistaken for an admonition; this replaces the previous regex-only label fallback.
 
 == 0.3.0 (2026-06-03)
 

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -273,6 +273,57 @@ Used for block delimiters (`----', `====', ...) and list markers (`*',
 `adoc-mode' and the convention in `markdown-mode'."
   :group 'asciidoc)
 
+;; Admonition faces.  Each paragraph admonition (`NOTE:', `TIP:', ...) gets a
+;; color-coded label and a subtle whole-block background, like Asciidoctor's
+;; rendered callouts.  Backgrounds use `:extend t' so they fill the line, and
+;; carry light/dark variants since a fixed tint can't suit both.
+
+(defface asciidoc-admonition-note-label-face
+  '((t :inherit font-lock-keyword-face :weight bold))
+  "Face for the `NOTE:' admonition label." :group 'asciidoc)
+
+(defface asciidoc-admonition-note-face
+  '((((background light)) :background "#ddeaff" :extend t)
+    (((background dark))  :background "#1b2638" :extend t))
+  "Background face for the body of a `NOTE:' admonition." :group 'asciidoc)
+
+(defface asciidoc-admonition-tip-label-face
+  '((t :inherit success :weight bold))
+  "Face for the `TIP:' admonition label." :group 'asciidoc)
+
+(defface asciidoc-admonition-tip-face
+  '((((background light)) :background "#defae4" :extend t)
+    (((background dark))  :background "#16291c" :extend t))
+  "Background face for the body of a `TIP:' admonition." :group 'asciidoc)
+
+(defface asciidoc-admonition-important-label-face
+  '((t :inherit font-lock-warning-face :weight bold))
+  "Face for the `IMPORTANT:' admonition label." :group 'asciidoc)
+
+(defface asciidoc-admonition-important-face
+  '((((background light)) :background "#f0e6ff" :extend t)
+    (((background dark))  :background "#241a33" :extend t))
+  "Background face for the body of an `IMPORTANT:' admonition."
+  :group 'asciidoc)
+
+(defface asciidoc-admonition-caution-label-face
+  '((t :inherit warning :weight bold))
+  "Face for the `CAUTION:' admonition label." :group 'asciidoc)
+
+(defface asciidoc-admonition-caution-face
+  '((((background light)) :background "#fff1e0" :extend t)
+    (((background dark))  :background "#332617" :extend t))
+  "Background face for the body of a `CAUTION:' admonition." :group 'asciidoc)
+
+(defface asciidoc-admonition-warning-label-face
+  '((t :inherit error :weight bold))
+  "Face for the `WARNING:' admonition label." :group 'asciidoc)
+
+(defface asciidoc-admonition-warning-face
+  '((((background light)) :background "#ffe5e8" :extend t)
+    (((background dark))  :background "#331a1f" :extend t))
+  "Background face for the body of a `WARNING:' admonition." :group 'asciidoc)
+
 (defcustom asciidoc-superscript-raise 0.4
   "How far to raise superscript text, as a fraction of line height.
 Applied as a `display' \\='(raise ...) property on top of
@@ -518,17 +569,93 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
     (replacement))
   "Font-lock feature list for `asciidoc-mode'.")
 
-;;; Admonition labels
+;;; Admonitions
 
-;; The block grammar consumes a paragraph-style admonition label (e.g.
-;; \"NOTE\") without emitting a node for it, so it can't be highlighted
-;; via tree-sitter.  A small font-lock keyword fills the gap and, unlike
-;; the previous tree-sitter rule, leaves the admonition body to inline
-;; fontification instead of overriding it.
-(defvar asciidoc--admonition-font-lock-keywords
-  '(("^\\(?:NOTE\\|TIP\\|IMPORTANT\\|CAUTION\\|WARNING\\):"
-     0 'font-lock-keyword-face t))
-  "Font-lock keywords for paragraph-style admonition labels.")
+;; A paragraph admonition (`NOTE: text', possibly wrapping over several
+;; lines) is given a color-coded label and a whole-block background, like
+;; Asciidoctor's rendered callouts.  The grammar only spans the first line
+;; (and emits the label as a zero-width marker), so this is done with a
+;; font-lock matcher that finds the `admonition' node via tree-sitter --
+;; which keeps a `NOTE:'-looking line inside a code block from matching --
+;; and extends the block to the next blank line.  A
+;; `font-lock-extend-region-functions' entry re-fontifies the whole block
+;; when an edit lands on a continuation line.
+
+(defcustom asciidoc-fontify-admonition-blocks t
+  "When non-nil, tint the whole body of a paragraph admonition.
+The label is always color-coded; this controls only the background that
+spans the admonition's body lines."
+  :type 'boolean
+  :group 'asciidoc)
+
+(defconst asciidoc--admonition-label-regexp
+  "\\(\\(?:NOTE\\|TIP\\|IMPORTANT\\|CAUTION\\|WARNING\\):\\)\\(?: \\|$\\)"
+  "Regexp matching a paragraph admonition label at the start of a line.
+Group 1 is the `LABEL:' text, without the trailing space.")
+
+(defun asciidoc--admonition-kind (node)
+  "Return the kind (\"note\", \"tip\", ...) of an `admonition' NODE."
+  (let ((type (treesit-node-type (treesit-node-child node 0))))
+    (when (and type (string-prefix-p "admonition_" type))
+      (substring type (length "admonition_")))))
+
+(defun asciidoc--admonition-block-end (beg)
+  "Return the end of the admonition paragraph starting at BEG.
+That is the start of the next blank line, or end of buffer."
+  (save-excursion
+    (goto-char beg)
+    (if (re-search-forward "\n[ \t]*\n" nil t)
+        (match-beginning 0)
+      (point-max))))
+
+(defun asciidoc--admonition-label-end (beg)
+  "Return the end of the `LABEL:' starting at line position BEG, or nil."
+  (save-excursion
+    (goto-char beg)
+    (and (looking-at asciidoc--admonition-label-regexp) (match-end 1))))
+
+(defun asciidoc--fontify-admonitions (limit)
+  "Font-lock matcher: give paragraph admonitions a block look up to LIMIT.
+Returns nil and applies faces as a side effect."
+  (when (treesit-parser-list nil 'asciidoc)
+    (save-match-data
+      (let ((root (treesit-buffer-root-node 'asciidoc)))
+        (pcase-dolist (`(_ . ,node)
+                       (treesit-query-capture
+                        root '((admonition) @a) (point) limit))
+          (when-let* ((kind (asciidoc--admonition-kind node))
+                      (label-beg (save-excursion
+                                   (goto-char (treesit-node-start node))
+                                   (line-beginning-position)))
+                      (label-end (asciidoc--admonition-label-end label-beg))
+                      (block-end (asciidoc--admonition-block-end label-beg)))
+            (when asciidoc-fontify-admonition-blocks
+              (font-lock-prepend-text-property
+               label-beg block-end 'face
+               (intern (format "asciidoc-admonition-%s-face" kind))))
+            (font-lock-prepend-text-property
+             label-beg label-end 'face
+             (intern (format "asciidoc-admonition-%s-label-face" kind)))
+            (put-text-property label-beg block-end 'font-lock-multiline t))))))
+  nil)
+
+;; Bound dynamically by font-lock around `font-lock-extend-region-functions'.
+(defvar font-lock-beg)
+(defvar font-lock-end)
+
+(defun asciidoc--font-lock-extend-region ()
+  "Extend the font-lock region back to an admonition label above the region.
+For `font-lock-extend-region-functions', so editing a continuation line
+re-fontifies the whole admonition block."
+  (save-excursion
+    (goto-char font-lock-beg)
+    (let ((para-start (if (re-search-backward "\n[ \t]*\n" nil t)
+                          (match-end 0)
+                        (point-min))))
+      (when (and (< para-start font-lock-beg)
+                 (progn (goto-char para-start)
+                        (looking-at-p asciidoc--admonition-label-regexp)))
+        (setq font-lock-beg para-start)))))
 
 ;;; Native source block fontification
 
@@ -1276,6 +1403,12 @@ Install them with \\[asciidoc-install-grammars].
                 (append '(display keymap mouse-face follow-link help-echo)
                         font-lock-extra-managed-props))
 
+    ;; Admonition blocks span several lines; let font-lock re-fontify the
+    ;; whole block when an edit lands inside it.
+    (setq-local font-lock-multiline t)
+    (add-hook 'font-lock-extend-region-functions
+              #'asciidoc--font-lock-extend-region nil t)
+
     ;; Imenu
     (setq-local treesit-simple-imenu-settings
                 asciidoc--treesit-simple-imenu-settings)
@@ -1312,7 +1445,7 @@ Install them with \\[asciidoc-install-grammars].
   ;; The code-block matcher runs after tree-sitter has applied the verbatim
   ;; string face, replacing it with native faces (see
   ;; `asciidoc--fontify-code-blocks').
-  (font-lock-add-keywords nil asciidoc--admonition-font-lock-keywords)
+  (font-lock-add-keywords nil '((asciidoc--fontify-admonitions)))
   (font-lock-add-keywords nil '((asciidoc--fontify-code-blocks)) 'append))
 
 ;;; Keymap

--- a/test/asciidoc-mode-integration-test.el
+++ b/test/asciidoc-mode-integration-test.el
@@ -139,14 +139,16 @@ OCCURRENCE selects which match (default 1)."
   (it "fontifies the admonition label"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-sample-buffer
-      ;; The whole "NOTE:" label (keyword + colon) is highlighted via a
-      ;; font-lock keyword, since the grammar doesn't expose it as a node.
+      ;; The whole "NOTE:" label (keyword + colon) gets the color-coded
+      ;; per-type label face.
       (goto-char (point-min))
       (search-forward "NOTE:")
-      (expect (get-text-property (match-beginning 0) 'face)
-              :to-equal 'font-lock-keyword-face)
-      (expect (get-text-property (+ (match-beginning 0) 4) 'face)
-              :to-equal 'font-lock-keyword-face)))
+      (expect (asciidoc-test-face-at-includes
+               (match-beginning 0) 'asciidoc-admonition-note-label-face)
+              :to-be-truthy)
+      (expect (asciidoc-test-face-at-includes
+               (+ (match-beginning 0) 4) 'asciidoc-admonition-note-label-face)
+              :to-be-truthy)))
 
   (it "fontifies block macro name"
     (assume asciidoc-test-grammars-available skip-reason)

--- a/test/asciidoc-mode-smoke-test.el
+++ b/test/asciidoc-mode-smoke-test.el
@@ -97,7 +97,8 @@
                               asciidoc-anchor-face          ; [[id]] anchors
                               asciidoc-metadata-key-face    ; :attr: names
                               asciidoc-metadata-value-face  ; :attr: values
-                              font-lock-keyword-face        ; admonition labels
+                              asciidoc-admonition-note-label-face ; NOTE: label
+                              asciidoc-admonition-note-face       ; admonition block bg
                               font-lock-comment-face        ; // comments
                               asciidoc-markup-face          ; block/table delimiters, list markers
                               font-lock-preprocessor-face   ; element attributes

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -524,34 +524,69 @@
     (unless asciidoc-test-grammars-available
       (setq skip-reason "tree-sitter grammars not installed")))
 
-  (it "fontifies the NOTE label as a keyword"
+  (it "color-codes the NOTE label"
     (assume asciidoc-test-grammars-available skip-reason)
-    ;; The whole "NOTE:" label is highlighted via a font-lock keyword.
     (with-fontified-asciidoc-buffer "= Title\n\nNOTE: This is a note.\n"
       (let ((pos (string-match "NOTE:" (buffer-string))))
-        ;; the keyword itself
-        (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'font-lock-keyword-face)
-        ;; the trailing colon
-        (expect (asciidoc-test-face-at (+ 1 pos 4))
-                :to-equal 'font-lock-keyword-face))))
+        ;; the keyword and its trailing colon both get the label face
+        (expect (asciidoc-test-face-at-includes
+                 (1+ pos) 'asciidoc-admonition-note-label-face)
+                :to-be-truthy)
+        (expect (asciidoc-test-face-at-includes
+                 (+ 1 pos 4) 'asciidoc-admonition-note-label-face)
+                :to-be-truthy))))
+
+  (it "tints the whole admonition body, including continuation lines"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer
+        "= Title\n\nWARNING: first line\nsecond line\n\nplain paragraph.\n"
+      (let ((cont (string-match "second line" (buffer-string)))
+            (plain (string-match "plain paragraph" (buffer-string))))
+        ;; the continuation line carries the block background
+        (expect (asciidoc-test-face-at-includes
+                 (1+ cont) 'asciidoc-admonition-warning-face)
+                :to-be-truthy)
+        ;; the following plain paragraph does not
+        (expect (asciidoc-test-face-at-includes
+                 (1+ plain) 'asciidoc-admonition-warning-face)
+                :to-be nil))))
 
   (it "does not clobber inline markup in the admonition body"
     (assume asciidoc-test-grammars-available skip-reason)
-    ;; Inline `code` inside an admonition body must still be fontified as
-    ;; monospace, not overridden by the admonition label highlighting.
+    ;; Inline `code` keeps its monospace face; the block background is
+    ;; layered underneath, not in place of it.
     (with-fontified-asciidoc-buffer "= Title\n\nNOTE: see `code` here.\n"
       (let ((pos (string-match "`code`" (buffer-string))))
-        (expect (asciidoc-test-face-at (1+ pos))
-                :to-equal 'asciidoc-code-face))))
+        (expect (asciidoc-test-face-at-includes (1+ pos) 'asciidoc-code-face)
+                :to-be-truthy))))
 
-  (it "recognizes all admonition labels"
+  (it "does not treat a NOTE: line inside a listing block as an admonition"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "= T\n\n----\nNOTE: just code\n----\n"
+      (let ((pos (string-match "NOTE:" (buffer-string))))
+        (expect (asciidoc-test-face-at-includes
+                 (1+ pos) 'asciidoc-admonition-note-label-face)
+                :to-be nil))))
+
+  (it "leaves the body untinted when block fontification is off"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (let ((asciidoc-fontify-admonition-blocks nil))
+      (with-fontified-asciidoc-buffer "= Title\n\nNOTE: a note.\n"
+        (let ((pos (string-match "a note" (buffer-string))))
+          ;; label still color-coded, but no background on the body
+          (expect (asciidoc-test-face-at-includes
+                   (1+ pos) 'asciidoc-admonition-note-face)
+                  :to-be nil)))))
+
+  (it "recognizes all admonition labels with per-type faces"
     (assume asciidoc-test-grammars-available skip-reason)
     (dolist (label '("NOTE" "TIP" "IMPORTANT" "CAUTION" "WARNING"))
       (with-fontified-asciidoc-buffer (format "= Title\n\n%s: body.\n" label)
-        (let ((pos (string-match label (buffer-string))))
-          (expect (asciidoc-test-face-at (1+ pos))
-                  :to-equal 'font-lock-keyword-face))))))
+        (let ((pos (string-match label (buffer-string)))
+              (face (intern (format "asciidoc-admonition-%s-label-face"
+                                    (downcase label)))))
+          (expect (asciidoc-test-face-at-includes (1+ pos) face)
+                  :to-be-truthy))))))
 
 ;;; Native source block fontification
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -30,6 +30,12 @@ CONTENT is inserted and BODY is evaluated after fontification."
   "Return the face at POS in the current buffer."
   (get-text-property pos 'face))
 
+(defun asciidoc-test-face-at-includes (pos face)
+  "Return non-nil if FACE is among the face(s) applied at POS.
+Handles the `face' property being either a single face or a list."
+  (let ((f (get-text-property pos 'face)))
+    (memq face (if (listp f) f (list f)))))
+
 (defun asciidoc-test-mono-face (text needle)
   "Fontify TEXT in `asciidoc-mode' and return the face just inside NEEDLE.
 NEEDLE is a substring (e.g. a backtick-delimited code span); the face is


### PR DESCRIPTION
Admonitions are the most common AsciiDoc block in real docs - the CIDER manual alone has 172 paragraph-style ones, and they routinely wrap over several lines. Until now only the `NOTE:` label was colored, with a single keyword face for every type.

This gives each type (NOTE/TIP/IMPORTANT/CAUTION/WARNING) its own label face plus a subtle whole-block background that spans the body, including the lines it wraps onto - like Asciidoctor renders callouts. Backgrounds are light/dark aware and fully customizable, and the body tint can be turned off via `asciidoc-fontify-admonition-blocks` (the label stays color-coded).

### How
The continuation lines are separate `paragraph` nodes in the tree (this grammar treats every line as its own block), so a single node cannot span the admonition. The implementation is a font-lock matcher that:
- finds admonitions via the tree-sitter `admonition` node - so a `NOTE:`-looking line inside a listing block is *not* mistaken for one (the old regex-only fallback could not tell), and
- extends the block to the next blank line, and
- registers a `font-lock-extend-region-functions` entry so editing a continuation line re-fontifies the whole block.

This also replaces the old regex label workaround entirely.

The background hex values are a first cut (light/dark variants); easy to retune since theyre customizable faces. 167 specs pass; fontifying a real CIDER page is ~18ms.