### PR TITLE
Highlight typographic (curved) quotes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,10 @@
 
 == main (unreleased)
 
+=== New Features
+
+* Highlight typographic (curved) quotes (`"\`double\`"` and `'\`single\`'`), now that the grammar parses them as a distinct node. The two-character quote markers fade into the markup face, and the quoted text stays plain prose; the inner backticks are no longer mistaken for an inline code span.
+
 == 0.4.0 (2026-06-11)
 
 === Bug Fixes

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -359,6 +359,20 @@ font-lock rule."
       (treesit-fontify-with-override beg fin face override)
       (put-text-property beg fin 'display (list 'raise raise)))))
 
+(defun asciidoc--fontify-typographic-quote (node override start end &rest _)
+  "Fade the curly-quote delimiters of a `typographic_quote' NODE.
+The two-character opener and closer fade into the markup face; the quoted
+text stays plain prose, since it renders as an ordinary phrase wrapped in
+curved quotes.  START, END and OVERRIDE come from the font-lock rule."
+  (let ((beg (treesit-node-start node))
+        (fin (treesit-node-end node)))
+    (dolist (range (list (cons beg (+ beg 2)) (cons (- fin 2) fin)))
+      (let ((rb (max start (car range)))
+            (re (min end (cdr range))))
+        (when (< rb re)
+          (treesit-fontify-with-override
+           rb re 'asciidoc-markup-face override))))))
+
 (defcustom asciidoc-role-face-alist
   '(("line-through" . asciidoc-strike-through-face)
     ("underline"    . asciidoc-underline-face)
@@ -517,6 +531,7 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
      (highlight) @asciidoc-highlight-face
      (superscript) @asciidoc--fontify-raised-span
      (subscript) @asciidoc--fontify-raised-span
+     (typographic_quote) @asciidoc--fontify-typographic-quote
      (passthrough) @font-lock-string-face)
 
    ;; A custom-style span (`[.role]#text#') reuses the `highlight' node for

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -142,6 +142,24 @@
         (expect (asciidoc-test-face-at (+ (point-min) pos))
                 :to-equal 'asciidoc-code-face))))
 
+  (it "fades typographic-quote delimiters and leaves the text plain"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "say \"`hello`\" now\n"
+      (let ((open (string-match "\"`" (buffer-string)))
+            (text (string-match "hello" (buffer-string))))
+        ;; both characters of the opener fade into the markup face
+        (expect (asciidoc-test-face-at (1+ open)) :to-equal 'asciidoc-markup-face)
+        (expect (asciidoc-test-face-at (+ 2 open)) :to-equal 'asciidoc-markup-face)
+        ;; the quoted prose stays unfaced
+        (expect (asciidoc-test-face-at (1+ text)) :to-be nil))))
+
+  (it "fontifies single typographic quotes too"
+    (assume asciidoc-test-grammars-available skip-reason)
+    (with-fontified-asciidoc-buffer "an '`aside`' here\n"
+      (let ((open (string-match "'`" (buffer-string))))
+        (expect (asciidoc-test-face-at (1+ open))
+                :to-equal 'asciidoc-markup-face))))
+
   (it "fontifies superscript text and raises it"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "E = mc^2^ today\n"


### PR DESCRIPTION
The inline grammar now parses curved quotes - `"`+text+`"` (double) and the single-quote variant - as a `typographic_quote` node (upstream tree-sitter-asciidoc #92), instead of mis-reading the inner backticks as a code span.

This wires up highlighting: the two-character quote markers fade into `asciidoc-markup-face` (like other structural markup), and the quoted text stays plain prose, since it renders as an ordinary phrase wrapped in curved quotes. Monospace spans are unaffected.

169 specs pass.