### PR TITLE
Don't single out URLs inside inline-macro attribute lists

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,10 @@
 
 * Highlight typographic (curved) quotes (`"\`double\`"` and `'\`single\`'`), now that the grammar parses them as a distinct node. The two-character quote markers fade into the markup face, and the quoted text stays plain prose; the inner backticks are no longer mistaken for an inline code span.
 
+=== Bug Fixes
+
+* Stop singling out a URL inside an inline macro's attribute list (e.g. the `link="..."` target of an `image:` macro). Such a URL was fontified as a standalone link -- highlighted and clickable -- only when written literally, so a literal `link=` and a `{attr}`-based one looked different. It is now left as plain attribute text in both cases.
+
 == 0.4.0 (2026-06-11)
 
 === Bug Fixes

--- a/asciidoc-mode.el
+++ b/asciidoc-mode.el
@@ -410,14 +410,35 @@ Applied as a `keymap' text property by `asciidoc--fontify-reference'."
   "RET" #'asciidoc-follow-reference-at-point
   "<mouse-2>" #'asciidoc-follow-reference-at-point)
 
+(defun asciidoc--in-inline-macro-p (node)
+  "Return non-nil if NODE is nested inside an `inline_macro'.
+A URL or label that lives in a macro's attribute list (e.g. the `link='
+target of an `image:' macro) is part of the macro, not a standalone
+reference in the prose."
+  (treesit-parent-until
+   node (lambda (n) (equal (treesit-node-type n) "inline_macro"))))
+
+(defun asciidoc--fontify-url (node override start end &rest _)
+  "Fontify a `link_url' NODE with the URL face, unless it's inside a macro.
+A URL inside an inline macro's attribute list is left as plain attribute
+text, so it isn't singled out and so literal and `{attr}'-based macro
+targets look the same.  START, END and OVERRIDE come from the rule."
+  (unless (asciidoc--in-inline-macro-p node)
+    (treesit-fontify-with-override
+     (max start (treesit-node-start node)) (min end (treesit-node-end node))
+     'asciidoc-url-face override)))
+
 (defun asciidoc--fontify-reference (node _override start end &rest _)
   "Make the navigable reference NODE clickable.
 Adds the keymap, mouse highlight and tooltip; the link/cross-reference
 faces are applied by their own rules.  Non-navigable inline macros (e.g.
-`image:', `kbd:') are skipped.  START and END bound the fontified region."
-  (when (or (member (treesit-node-type node) '("xref" "autolink"))
-            (member (asciidoc--node-field node "macro_name")
-                    '("link" "mailto" "xref")))
+`image:', `kbd:') are skipped, as is an autolink nested inside a macro's
+attribute list.  START and END bound the fontified region."
+  (when (and (not (and (equal (treesit-node-type node) "autolink")
+                       (asciidoc--in-inline-macro-p node)))
+             (or (member (treesit-node-type node) '("xref" "autolink"))
+                 (member (asciidoc--node-field node "macro_name")
+                         '("link" "mailto" "xref"))))
     (let ((beg (max start (treesit-node-start node)))
           (fin (min end (treesit-node-end node))))
       (when (< beg fin)
@@ -549,7 +570,7 @@ faces are applied by their own rules.  Non-navigable inline macros (e.g.
    :language 'asciidoc-inline
    :feature 'inline-link
    '((autolink) @asciidoc--fontify-reference
-     (link_url) @asciidoc-url-face
+     (link_url) @asciidoc--fontify-url
      (email) @asciidoc-url-face
      (xref) @asciidoc-cross-reference-face
      (xref) @asciidoc--fontify-reference

--- a/test/asciidoc-mode-test.el
+++ b/test/asciidoc-mode-test.el
@@ -202,6 +202,16 @@
         (expect (asciidoc-test-face-at (+ (point-min) label))
                 :to-equal 'asciidoc-link-face))))
 
+  (it "leaves a URL inside a macro's attribute list as plain text"
+    (assume asciidoc-test-grammars-available skip-reason)
+    ;; The `link=' target of an `image:' macro should not be singled out as
+    ;; a standalone URL, so it matches a `{attr}'-based target.
+    (with-fontified-asciidoc-buffer
+        "image:badge.svg[Badge,link=\"https://example.com/x\"]\n"
+      (let ((pos (string-match "https" (buffer-string))))
+        (expect (asciidoc-test-face-at (+ (point-min) pos)) :to-be nil)
+        (expect (get-text-property (+ (point-min) pos) 'keymap) :to-be nil))))
+
   (it "fontifies footnote marker and text distinctly"
     (assume asciidoc-test-grammars-available skip-reason)
     (with-fontified-asciidoc-buffer "Claim footnote:[a source] here.\n"


### PR DESCRIPTION
A URL in an inline macro's attribute list - e.g. the `link="..."` target of an `image:` badge - was parsed as a nested `autolink` and fontified as a standalone link (URL face + clickable), but **only when written literally**. A `{attr}`-based `link=` value stayed plain. So a README badge block fontified inconsistently (MELPA/License links coloured, the `{url-repo}`-based CI link not), and the secondary `link=` target ended up more prominent than the image's own `.svg` source.

Skip the URL face and clickable affordance for an `autolink`/`link_url` nested inside an `inline_macro`, so literal and `{attr}`-based macro targets look the same. Standalone URLs and link labels in prose are unchanged.

170 specs pass.